### PR TITLE
Bootstrap public-safe GitHub Actions runner

### DIFF
--- a/.github/workflows/public-fork-maintenance.yml
+++ b/.github/workflows/public-fork-maintenance.yml
@@ -72,7 +72,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ secrets.PUBLIC_OPS_APP_CLIENT_ID }}
+          client-id: ${{ secrets.PUBLIC_OPS_APP_CLIENT_ID }}
           private-key: ${{ secrets.PUBLIC_OPS_APP_PRIVATE_KEY }}
           owner: SupraCraft
           repositories: |
@@ -111,7 +111,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ secrets.PUBLIC_OPS_APP_CLIENT_ID }}
+          client-id: ${{ secrets.PUBLIC_OPS_APP_CLIENT_ID }}
           private-key: ${{ secrets.PUBLIC_OPS_APP_PRIVATE_KEY }}
           owner: SemperSupra
           repositories: |

--- a/.github/workflows/public-fork-maintenance.yml
+++ b/.github/workflows/public-fork-maintenance.yml
@@ -1,0 +1,133 @@
+name: Public fork maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Operation mode
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - apply
+      create_ci_issues:
+        description: Create missing fork-local CI work items during apply
+        required: true
+        default: true
+        type: boolean
+      confirmation:
+        description: For apply, enter APPLY-PUBLIC-FORK-MAINTENANCE
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-fork-maintenance
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Read-only topology and policy audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Require main for apply
+        if: ${{ inputs.mode == 'apply' }}
+        shell: pwsh
+        run: |
+          if ('${{ github.ref }}' -ne 'refs/heads/main') {
+            throw 'Apply is permitted only from refs/heads/main.'
+          }
+          if ('${{ inputs.confirmation }}' -ne 'APPLY-PUBLIC-FORK-MAINTENANCE') {
+            throw 'Apply confirmation phrase does not match.'
+          }
+
+      - name: Run read-only audit
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./candidates/Repair-UpstreamForks.ps1 -AuditOnly
+
+  apply-supracraft:
+    name: Apply SupraCraft fork maintenance
+    if: ${{ inputs.mode == 'apply' }}
+    needs: audit
+    runs-on: ubuntu-latest
+    environment: public-ops-write
+    steps:
+      - name: Check out exact main revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Mint scoped SupraCraft installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.PUBLIC_OPS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUBLIC_OPS_APP_PRIVATE_KEY }}
+          owner: SupraCraft
+          repositories: |
+            VanillaCord
+            Bridge
+
+      - name: Apply validated SupraCraft maintenance
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_MUTATION_TOKEN: ${{ steps.app-token.outputs.token }}
+          CREATE_CI_ISSUES: ${{ inputs.create_ci_issues }}
+        run: |
+          $invoke = @{
+            Fork = @('SupraCraft/VanillaCord', 'SupraCraft/Bridge')
+          }
+          if ($env:CREATE_CI_ISSUES -eq 'true') {
+            $invoke.CreateCiIssues = $true
+          }
+          ./candidates/Repair-UpstreamForks.ps1 @invoke
+
+  apply-sempersupra:
+    name: Apply SemperSupra fork maintenance
+    if: ${{ inputs.mode == 'apply' }}
+    needs: audit
+    runs-on: ubuntu-latest
+    environment: public-ops-write
+    steps:
+      - name: Check out exact main revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Mint scoped SemperSupra installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.PUBLIC_OPS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUBLIC_OPS_APP_PRIVATE_KEY }}
+          owner: SemperSupra
+          repositories: |
+            OpenXcom
+
+      - name: Apply validated SemperSupra maintenance
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_MUTATION_TOKEN: ${{ steps.app-token.outputs.token }}
+          CREATE_CI_ISSUES: ${{ inputs.create_ci_issues }}
+        run: |
+          $invoke = @{
+            Fork = @('SemperSupra/OpenXcom')
+          }
+          if ($env:CREATE_CI_ISSUES -eq 'true') {
+            $invoke.CreateCiIssues = $true
+          }
+          ./candidates/Repair-UpstreamForks.ps1 @invoke

--- a/.github/workflows/public-safe-validation.yml
+++ b/.github/workflows/public-safe-validation.yml
@@ -1,0 +1,75 @@
+name: Public-safe validation
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-safe-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  powershell-parse:
+    name: PowerShell parse (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Report runner toolchain
+        shell: pwsh
+        run: |
+          $PSVersionTable
+          gh --version
+
+      - name: Parse all PowerShell candidates
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $files = @(Get-ChildItem -Path candidates -Filter '*.ps1' -File -Recurse)
+          if ($files.Count -eq 0) {
+            throw 'No PowerShell candidate files were found.'
+          }
+
+          foreach ($file in $files) {
+            $tokens = $null
+            $errors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile(
+              $file.FullName,
+              [ref]$tokens,
+              [ref]$errors
+            )
+
+            if ($errors.Count -gt 0) {
+              $errors | Format-List *
+              throw "PowerShell parser errors in $($file.FullName)"
+            }
+
+            Write-Host "PASS parser: $($file.FullName)"
+          }
+
+  fork-helper-audit:
+    name: Fork helper read-only audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Run candidate in audit-only mode
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./candidates/Repair-UpstreamForks.ps1 -AuditOnly

--- a/candidates/Repair-UpstreamForks.ps1
+++ b/candidates/Repair-UpstreamForks.ps1
@@ -22,7 +22,9 @@
 [CmdletBinding(SupportsShouldProcess)]
 param(
     [switch]$AuditOnly,
-    [switch]$CreateCiIssues
+    [switch]$CreateCiIssues,
+    [ValidateSet('SupraCraft/VanillaCord', 'SupraCraft/Bridge', 'SemperSupra/OpenXcom')]
+    [string[]]$Fork
 )
 
 Set-StrictMode -Version Latest
@@ -38,6 +40,28 @@ function Invoke-GhJson {
     }
     if (-not $raw) { return $null }
     return ($raw | Out-String | ConvertFrom-Json)
+}
+
+function Invoke-GhMutation {
+    param(
+        [Parameter(Mandatory)][string[]]$Args
+    )
+
+    if (-not $env:GH_MUTATION_TOKEN) {
+        throw 'Mutation requested but GH_MUTATION_TOKEN is not set.'
+    }
+
+    $readToken = $env:GH_TOKEN
+    try {
+        $env:GH_TOKEN = $env:GH_MUTATION_TOKEN
+        & gh @Args
+        if ($LASTEXITCODE -ne 0) {
+            throw "gh $($Args -join ' ') mutation failed."
+        }
+    }
+    finally {
+        $env:GH_TOKEN = $readToken
+    }
 }
 
 function Test-GhPath {
@@ -168,6 +192,13 @@ Public CI may contain ordinary public-safe tests only. Do not publish comprehens
     }
 )
 
+if ($Fork) {
+    $forks = @($forks | Where-Object { $_.Fork -in $Fork })
+    if ($forks.Count -eq 0) {
+        throw 'No configured forks matched -Fork.'
+    }
+}
+
 $policyPaths = @(
     'AI_POLICY.md',
     '.github/AI_POLICY.md',
@@ -212,15 +243,11 @@ $results = foreach ($entry in $forks) {
 
     if (-not $AuditOnly -and -not $repo.has_issues) {
         if ($PSCmdlet.ShouldProcess($entry.Fork, 'Enable fork-local GitHub Issues')) {
-            & gh api --method PATCH "repos/$($entry.Fork)" -F has_issues=true --silent
-            if ($LASTEXITCODE -ne 0) {
-                throw "Failed to enable Issues for $($entry.Fork)"
-            }
+            Invoke-GhMutation -Args @('api', '--method', 'PATCH', "repos/$($entry.Fork)", '-F', 'has_issues=true', '--silent')
             Write-Host 'Enabled fork-local Issues.' -ForegroundColor Green
         }
     }
 
-    # Search only explicit/common policy locations. Absence is UNKNOWN, never "allowed".
     $policyHits = @()
     foreach ($path in $policyPaths) {
         if (Test-GhPath -Repo $actualParent -Path $path) {
@@ -253,15 +280,11 @@ $results = foreach ($entry in $forks) {
     }
 
     if ($CreateCiIssues -and -not $AuditOnly) {
-        # Idempotence: do not create a second issue with the same title.
         $existing = & gh issue list --repo $entry.Fork --state all --search ('"{0}" in:title' -f $entry.CiTitle) --json number,title --limit 20 | ConvertFrom-Json
         $match = @($existing | Where-Object title -eq $entry.CiTitle)
         if ($match.Count -eq 0) {
             if ($PSCmdlet.ShouldProcess($entry.Fork, "Create CI issue '$($entry.CiTitle)'")) {
-                & gh issue create --repo $entry.Fork --title $entry.CiTitle --body $entry.CiBody
-                if ($LASTEXITCODE -ne 0) {
-                    throw "Failed to create CI issue in $($entry.Fork)"
-                }
+                Invoke-GhMutation -Args @('issue', 'create', '--repo', $entry.Fork, '--title', $entry.CiTitle, '--body', $entry.CiBody)
             }
         } else {
             Write-Host "CI issue already exists as #$($match[0].number); skipped."
@@ -295,8 +318,12 @@ Useful invocations:
   # Audit only; no changes
   ./Repair-UpstreamForks.ps1 -AuditOnly
 
-  # Enable Issues on the three forks
+  # Mutations require GH_MUTATION_TOKEN in addition to the read-only GH_TOKEN.
+  # Enable Issues on the configured forks
   ./Repair-UpstreamForks.ps1
+
+  # Limit a mutation to selected forks
+  ./Repair-UpstreamForks.ps1 -Fork SupraCraft/VanillaCord,SupraCraft/Bridge -CreateCiIssues
 
   # Enable Issues and create the fork-local CI work items idempotently
   ./Repair-UpstreamForks.ps1 -CreateCiIssues

--- a/candidates/Repair-UpstreamForks.ps1
+++ b/candidates/Repair-UpstreamForks.ps1
@@ -276,7 +276,7 @@ $results = foreach ($entry in $forks) {
         ForkIssuesBefore     = [bool]$repo.has_issues
         ParentIssues         = [bool]$upstream.has_issues
         AiContributionStatus = $aiStatus
-        PolicyFilesFound     = ($policyHits.Path -join ', ')
+        PolicyFilesFound     = (@($policyHits | ForEach-Object { $_.Path }) -join ', ')
     }
 }
 

--- a/candidates/Repair-UpstreamForks.ps1
+++ b/candidates/Repair-UpstreamForks.ps1
@@ -70,7 +70,10 @@ function Test-GhPath {
         [Parameter(Mandatory)][string]$Path
     )
     & gh api "repos/$Repo/contents/$Path" --silent 2>$null
-    return ($LASTEXITCODE -eq 0)
+    $found = ($LASTEXITCODE -eq 0)
+    # A missing optional policy path is expected probe data, not a script failure.
+    $global:LASTEXITCODE = 0
+    return $found
 }
 
 function Get-GhTextFile {

--- a/candidates/Repair-UpstreamForks.ps1
+++ b/candidates/Repair-UpstreamForks.ps1
@@ -1,0 +1,306 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+  Audit and repair the GitHub settings for the SupraCraft/SemperSupra upstream-oriented forks.
+
+.DESCRIPTION
+  - Verifies each repository is still a fork of the expected immediate upstream.
+  - Enables fork-local GitHub Issues.
+  - Reports fork/upstream default branches and selected repository settings.
+  - Searches common upstream contribution-policy locations for explicit AI/LLM policy text.
+  - Does NOT infer that silence means AI contributions are accepted.
+  - Does NOT change upstream repositories.
+  - Does NOT alter source, branches, merge history, or private/public boundaries.
+
+  Engineering-governance intent:
+    * Fork-local Issues are coordination/work tracking.
+    * Upstream-facing changes should follow upstream conventions.
+    * AI-written/AI-assisted changes are not proposed upstream until upstream acceptance
+      is explicit or a maintainer has confirmed the policy.
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [switch]$AuditOnly,
+    [switch]$CreateCiIssues
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-GhJson {
+    param(
+        [Parameter(Mandatory)][string[]]$Args
+    )
+    $raw = & gh @Args 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh $($Args -join ' ') failed:`n$raw"
+    }
+    if (-not $raw) { return $null }
+    return ($raw | Out-String | ConvertFrom-Json)
+}
+
+function Test-GhPath {
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$Path
+    )
+    & gh api "repos/$Repo/contents/$Path" --silent 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Get-GhTextFile {
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$Path
+    )
+    $obj = Invoke-GhJson -Args @('api', "repos/$Repo/contents/$Path")
+    if ($obj.encoding -ne 'base64') {
+        return $null
+    }
+    $bytes = [Convert]::FromBase64String(($obj.content -replace '\s',''))
+    return [Text.Encoding]::UTF8.GetString($bytes)
+}
+
+$forks = @(
+    [pscustomobject]@{
+        Fork = 'SupraCraft/VanillaCord'
+        ExpectedParent = 'ME1312/VanillaCord'
+        ExpectedDefaultBranch = 'master'
+        CiTitle = 'ci: add Minecraft/JDK compatibility matrix and upstream-release checks'
+        CiBody = @'
+## Objective
+Use public GitHub Actions to continuously validate this fork against supported Minecraft and Java versions while keeping changes suitable for upstream contribution.
+
+## Work
+- clean Maven build from the exact public SHA;
+- supported Java-version matrix;
+- ordinary public-safe smoke/unit tests;
+- scheduled detection of relevant Minecraft/upstream releases;
+- bounded compatibility runs when upstream versions change;
+- artifact hashes, SBOM, and provenance where useful;
+- immutable/pinned third-party Actions and least-privilege permissions;
+- machine-readable compatibility evidence.
+
+## Upstream discipline
+This is an upstream-oriented fork. Changes should preserve upstream layout, style, interfaces, and contribution conventions wherever practical. Fork-specific changes should be isolated and justified.
+
+Before proposing AI-written or materially AI-assisted changes upstream, obtain or cite an explicit upstream AI-contribution policy or maintainer approval. Silence is not approval.
+
+## Governance boundary
+Public CI uses public-safe inputs only. Do not publish private evaluators, comprehensive compatibility corpora, failure knowledge, credentials, or private-repository data merely to gain public runner capacity.
+
+## Acceptance
+- [ ] Clean build runs on supported Java versions.
+- [ ] Public-safe compatibility/smoke matrix is explicit.
+- [ ] Scheduled upstream/Minecraft change detection is bounded and deterministic.
+- [ ] Exact source/toolchain/upstream identities are recorded.
+- [ ] Upstream contribution path and AI-acceptance status are documented before upstream PRs.
+'@
+    }
+    [pscustomobject]@{
+        Fork = 'SupraCraft/Bridge'
+        ExpectedParent = 'ME1312/Bridge'
+        ExpectedDefaultBranch = 'master'
+        CiTitle = 'ci: add Java compatibility, Maven verification, and upstream-release checks'
+        CiBody = @'
+## Objective
+Use public GitHub Actions to continuously validate Bridge across supported Java/Maven environments while keeping the fork easy to upstream.
+
+## Work
+- clean Maven build/verify from exact public SHA;
+- supported JDK matrix;
+- ordinary public-safe unit/smoke tests;
+- bytecode/plugin compatibility checks using public-safe fixtures;
+- scheduled detection of relevant Java/Maven/upstream releases;
+- hashes, SBOM, and provenance for artifacts where useful;
+- immutable/pinned third-party Actions and least-privilege permissions.
+
+## Upstream discipline
+This is an upstream-oriented fork. Follow ME1312/Bridge naming, layout, style, Maven conventions, and PR expectations. Prefer narrowly upstreamable changes over fork-only divergence.
+
+Before proposing AI-written or materially AI-assisted changes upstream, obtain or cite an explicit upstream AI-contribution policy or maintainer approval. Silence is not approval.
+
+## Governance boundary
+Public CI uses only public-safe inputs and ordinary tests. Specialized evaluator knowledge, private corpora, reverse-engineering findings, credentials, and private-repository data remain outside public CI.
+
+## Acceptance
+- [ ] Supported JDK/Maven matrix passes from a clean checkout.
+- [ ] Public-safe bytecode/plugin smoke checks are automated.
+- [ ] Relevant upstream/runtime changes can trigger bounded checks.
+- [ ] Exact source/toolchain/upstream identities are recorded.
+- [ ] Upstream contribution path and AI-acceptance status are documented before upstream PRs.
+'@
+    }
+    [pscustomobject]@{
+        Fork = 'SemperSupra/OpenXcom'
+        ExpectedParent = 'MeridianOXC/OpenXcom'
+        ExpectedDefaultBranch = 'oxce-plus'
+        CiTitle = 'ci: add reproducible compiler/platform build matrix and public smoke tests'
+        CiBody = @'
+## Objective
+Use public GitHub Actions to validate the oxce-plus fork across supported public build environments without turning the fork into an unnecessarily divergent development line.
+
+## Work
+- reproduce the upstream/parent build conventions first;
+- clean compiler/platform build matrix where GitHub-hosted runners support it;
+- ordinary public-safe smoke/regression subset;
+- dependency/toolchain identity recording;
+- release artifact hashes, SBOM, and provenance where applicable;
+- scheduled parent/upstream change detection with bounded compatibility runs;
+- immutable/pinned third-party Actions and least-privilege permissions.
+
+## Upstream discipline
+The immediate parent is MeridianOXC/OpenXcom and the wider source lineage is OpenXcom/OpenXcom. Preserve the parent branch/layout/style and determine the appropriate contribution destination for each change before upstreaming it.
+
+Before proposing AI-written or materially AI-assisted changes upstream, obtain or cite an explicit AI-contribution policy or maintainer approval from the intended destination. Silence is not approval.
+
+## Governance boundary
+Public CI may contain ordinary public-safe tests only. Do not publish comprehensive evaluator corpora, rare failure knowledge, proprietary game assets, credentials, or private-repository data merely to use public runners.
+
+## Acceptance
+- [ ] CI reflects parent/upstream build conventions before adding fork-specific mechanics.
+- [ ] Supported public compiler/platform builds run reproducibly.
+- [ ] Ordinary public-safe smoke tests are clearly distinguished from comprehensive validation.
+- [ ] Exact source/toolchain/parent identities are recorded.
+- [ ] Intended upstream destination and AI-acceptance status are documented before upstream PRs.
+'@
+    }
+)
+
+$policyPaths = @(
+    'AI_POLICY.md',
+    '.github/AI_POLICY.md',
+    'AI.md',
+    '.github/AI.md',
+    'CONTRIBUTING.md',
+    '.github/CONTRIBUTING.md',
+    'AGENTS.md',
+    '.github/copilot-instructions.md'
+)
+
+& gh auth status
+if ($LASTEXITCODE -ne 0) {
+    throw 'GitHub CLI is not authenticated. Run: gh auth login'
+}
+
+$results = foreach ($entry in $forks) {
+    Write-Host "`n=== $($entry.Fork) ===" -ForegroundColor Cyan
+
+    $repo = Invoke-GhJson -Args @('api', "repos/$($entry.Fork)")
+    if (-not $repo.fork) {
+        throw "$($entry.Fork) is no longer reported by GitHub as a fork; refusing to mutate."
+    }
+
+    $actualParent = [string]$repo.parent.full_name
+    if ($actualParent -ne $entry.ExpectedParent) {
+        throw "$($entry.Fork) parent is '$actualParent', expected '$($entry.ExpectedParent)'; refusing to mutate."
+    }
+
+    if ([string]$repo.default_branch -ne $entry.ExpectedDefaultBranch) {
+        Write-Warning "$($entry.Fork) default branch is '$($repo.default_branch)', expected '$($entry.ExpectedDefaultBranch)'. No branch change will be made automatically."
+    }
+
+    $upstream = Invoke-GhJson -Args @('api', "repos/$actualParent")
+
+    Write-Host "Fork parent:       $actualParent"
+    Write-Host "Fork branch:       $($repo.default_branch)"
+    Write-Host "Upstream branch:   $($upstream.default_branch)"
+    Write-Host "Fork Issues:       $($repo.has_issues)"
+    Write-Host "Upstream Issues:   $($upstream.has_issues)"
+    Write-Host "Fork visibility:   $($repo.visibility)"
+
+    if (-not $AuditOnly -and -not $repo.has_issues) {
+        if ($PSCmdlet.ShouldProcess($entry.Fork, 'Enable fork-local GitHub Issues')) {
+            & gh api --method PATCH "repos/$($entry.Fork)" -F has_issues=true --silent
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to enable Issues for $($entry.Fork)"
+            }
+            Write-Host 'Enabled fork-local Issues.' -ForegroundColor Green
+        }
+    }
+
+    # Search only explicit/common policy locations. Absence is UNKNOWN, never "allowed".
+    $policyHits = @()
+    foreach ($path in $policyPaths) {
+        if (Test-GhPath -Repo $actualParent -Path $path) {
+            $text = Get-GhTextFile -Repo $actualParent -Path $path
+            if ($null -ne $text) {
+                $mentionsAI = $text -match '(?i)\b(AI|artificial intelligence|LLM|ChatGPT|Copilot|Claude|generated code)\b'
+                $policyHits += [pscustomobject]@{
+                    Path = $path
+                    MentionsAI = $mentionsAI
+                }
+            }
+        }
+    }
+
+    $explicitAi = @($policyHits | Where-Object MentionsAI)
+    $aiStatus = if ($explicitAi.Count -gt 0) {
+        'EXPLICIT_POLICY_TEXT_FOUND_REVIEW_REQUIRED'
+    } else {
+        'UNKNOWN_NO_EXPLICIT_REPO_POLICY_FOUND'
+    }
+
+    Write-Host "AI upstream status: $aiStatus"
+    if ($policyHits.Count -gt 0) {
+        Write-Host "Contribution/policy files found:"
+        $policyHits | ForEach-Object {
+            Write-Host ("  {0}  AI mention={1}" -f $_.Path, $_.MentionsAI)
+        }
+    } else {
+        Write-Host 'No common contribution/AI policy files found in the immediate parent.'
+    }
+
+    if ($CreateCiIssues -and -not $AuditOnly) {
+        # Idempotence: do not create a second issue with the same title.
+        $existing = & gh issue list --repo $entry.Fork --state all --search ('"{0}" in:title' -f $entry.CiTitle) --json number,title --limit 20 | ConvertFrom-Json
+        $match = @($existing | Where-Object title -eq $entry.CiTitle)
+        if ($match.Count -eq 0) {
+            if ($PSCmdlet.ShouldProcess($entry.Fork, "Create CI issue '$($entry.CiTitle)'")) {
+                & gh issue create --repo $entry.Fork --title $entry.CiTitle --body $entry.CiBody
+                if ($LASTEXITCODE -ne 0) {
+                    throw "Failed to create CI issue in $($entry.Fork)"
+                }
+            }
+        } else {
+            Write-Host "CI issue already exists as #$($match[0].number); skipped."
+        }
+    }
+
+    [pscustomobject]@{
+        Fork                 = $entry.Fork
+        Parent               = $actualParent
+        ForkDefaultBranch    = $repo.default_branch
+        ParentDefaultBranch  = $upstream.default_branch
+        ForkIssuesBefore     = [bool]$repo.has_issues
+        ParentIssues         = [bool]$upstream.has_issues
+        AiContributionStatus = $aiStatus
+        PolicyFilesFound     = ($policyHits.Path -join ', ')
+    }
+}
+
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+$results | Format-Table -AutoSize
+
+Write-Host @'
+
+Interpretation rule:
+  UNKNOWN_NO_EXPLICIT_REPO_POLICY_FOUND means exactly that: upstream AI acceptance
+  has NOT been established. Do not send AI-written/materially AI-assisted changes
+  upstream until the intended upstream maintainer explicitly allows them or an
+  authoritative policy says so.
+
+Useful invocations:
+  # Audit only; no changes
+  ./Repair-UpstreamForks.ps1 -AuditOnly
+
+  # Enable Issues on the three forks
+  ./Repair-UpstreamForks.ps1
+
+  # Enable Issues and create the fork-local CI work items idempotently
+  ./Repair-UpstreamForks.ps1 -CreateCiIssues
+
+  # Preview mutations
+  ./Repair-UpstreamForks.ps1 -CreateCiIssues -WhatIf
+'@


### PR DESCRIPTION
## Purpose

Bootstrap this repository as a deliberately constrained public execution lab for repository-operations tooling, and establish the first protected cross-repository maintenance lane.

## Changes

- establish a public/private authority boundary in the README;
- add a public-safe candidate copy of the fork-maintenance helper;
- add GitHub Actions parsing on Ubuntu, Windows, and macOS;
- run the helper in read-only audit mode using repository-scoped `GITHUB_TOKEN`;
- fix the strict-mode empty-policy runtime defect exposed by the first public run;
- add bounded target selection;
- separate read authority from mutation authority;
- add a manual protected maintenance workflow with audit/apply modes;
- require exact `main` ref and explicit confirmation before apply;
- use a protected environment only for apply jobs;
- mint separate short-lived GitHub App installation tokens for exact public target subsets;
- pin Actions to immutable commit SHAs;
- keep ordinary workflow permissions read-only.

## Safety boundary

Ordinary validation has no cross-repository write permission. Apply is manual only and depends on protected, narrowly scoped GitHub App credentials. No PAT or broad personal/org token path is included. Private source/control-plane identities are intentionally omitted from this public record.

## Acceptance

- parser succeeds on all required hosted runner OS families;
- live read-only audit succeeds against configured public targets;
- no mutation occurs during validation;
- apply depends on successful audit;
- apply is manual, main-only, explicitly confirmed, environment-protected, and narrowly App-scoped;
- repeated apply converges idempotently.