### PR TITLE
Promote validated fork helper to stable public ops entry point

### DIFF
--- a/.github/workflows/public-fork-maintenance.yml
+++ b/.github/workflows/public-fork-maintenance.yml
@@ -8,9 +8,7 @@ on:
         required: true
         default: audit
         type: choice
-        options:
-          - audit
-          - apply
+        options: [audit, apply]
       create_ci_issues:
         description: Create missing fork-local CI work items during apply
         required: true
@@ -38,22 +36,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Require main for apply
+      - name: Require main and confirmation for apply
         if: ${{ inputs.mode == 'apply' }}
         shell: pwsh
         run: |
-          if ('${{ github.ref }}' -ne 'refs/heads/main') {
-            throw 'Apply is permitted only from refs/heads/main.'
-          }
-          if ('${{ inputs.confirmation }}' -ne 'APPLY-PUBLIC-FORK-MAINTENANCE') {
-            throw 'Apply confirmation phrase does not match.'
-          }
+          if ('${{ github.ref }}' -ne 'refs/heads/main') { throw 'Apply is permitted only from refs/heads/main.' }
+          if ('${{ inputs.confirmation }}' -ne 'APPLY-PUBLIC-FORK-MAINTENANCE') { throw 'Apply confirmation phrase does not match.' }
 
       - name: Run read-only audit
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./candidates/Repair-UpstreamForks.ps1 -AuditOnly
+        run: ./scripts/github/Repair-UpstreamForks.ps1 -AuditOnly
 
   apply-supracraft:
     name: Apply SupraCraft fork maintenance
@@ -86,13 +80,9 @@ jobs:
           GH_MUTATION_TOKEN: ${{ steps.app-token.outputs.token }}
           CREATE_CI_ISSUES: ${{ inputs.create_ci_issues }}
         run: |
-          $invoke = @{
-            Fork = @('SupraCraft/VanillaCord', 'SupraCraft/Bridge')
-          }
-          if ($env:CREATE_CI_ISSUES -eq 'true') {
-            $invoke.CreateCiIssues = $true
-          }
-          ./candidates/Repair-UpstreamForks.ps1 @invoke
+          $invoke = @{ Fork = @('SupraCraft/VanillaCord', 'SupraCraft/Bridge') }
+          if ($env:CREATE_CI_ISSUES -eq 'true') { $invoke.CreateCiIssues = $true }
+          ./scripts/github/Repair-UpstreamForks.ps1 @invoke
 
   apply-sempersupra:
     name: Apply SemperSupra fork maintenance
@@ -114,8 +104,7 @@ jobs:
           client-id: ${{ secrets.PUBLIC_OPS_APP_CLIENT_ID }}
           private-key: ${{ secrets.PUBLIC_OPS_APP_PRIVATE_KEY }}
           owner: SemperSupra
-          repositories: |
-            OpenXcom
+          repositories: OpenXcom
 
       - name: Apply validated SemperSupra maintenance
         shell: pwsh
@@ -124,10 +113,6 @@ jobs:
           GH_MUTATION_TOKEN: ${{ steps.app-token.outputs.token }}
           CREATE_CI_ISSUES: ${{ inputs.create_ci_issues }}
         run: |
-          $invoke = @{
-            Fork = @('SemperSupra/OpenXcom')
-          }
-          if ($env:CREATE_CI_ISSUES -eq 'true') {
-            $invoke.CreateCiIssues = $true
-          }
-          ./candidates/Repair-UpstreamForks.ps1 @invoke
+          $invoke = @{ Fork = @('SemperSupra/OpenXcom') }
+          if ($env:CREATE_CI_ISSUES -eq 'true') { $invoke.CreateCiIssues = $true }
+          ./scripts/github/Repair-UpstreamForks.ps1 @invoke

--- a/.github/workflows/public-safe-validation.yml
+++ b/.github/workflows/public-safe-validation.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Check out exact revision
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Report runner toolchain
         shell: pwsh
@@ -34,13 +36,14 @@ jobs:
           $PSVersionTable
           gh --version
 
-      - name: Parse all PowerShell candidates
+      - name: Parse public PowerShell tooling
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $files = @(Get-ChildItem -Path candidates -Filter '*.ps1' -File -Recurse)
+          $roots = @('candidates', 'scripts') | Where-Object { Test-Path $_ }
+          $files = @($roots | ForEach-Object { Get-ChildItem -Path $_ -Filter '*.ps1' -File -Recurse })
           if ($files.Count -eq 0) {
-            throw 'No PowerShell candidate files were found.'
+            throw 'No PowerShell files were found.'
           }
 
           foreach ($file in $files) {
@@ -51,12 +54,10 @@ jobs:
               [ref]$tokens,
               [ref]$errors
             )
-
             if ($errors.Count -gt 0) {
               $errors | Format-List *
               throw "PowerShell parser errors in $($file.FullName)"
             }
-
             Write-Host "PASS parser: $($file.FullName)"
           }
 
@@ -66,10 +67,11 @@ jobs:
     steps:
       - name: Check out exact revision
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
-      - name: Run candidate in audit-only mode
+      - name: Run stable entry point in audit-only mode
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          ./candidates/Repair-UpstreamForks.ps1 -AuditOnly
+        run: ./scripts/github/Repair-UpstreamForks.ps1 -AuditOnly

--- a/docs/public-fork-operations.md
+++ b/docs/public-fork-operations.md
@@ -1,0 +1,43 @@
+# Public fork operations
+
+This repository provides a public-safe execution surface for GitHub repository operations that benefit from GitHub-hosted runners.
+
+## Stable entry point
+
+Use `scripts/github/Repair-UpstreamForks.ps1`.
+
+The stable entry point delegates to the byte-validated implementation in `candidates/Repair-UpstreamForks.ps1`. Keeping the candidate preserves the exact provenance object that was exercised on GitHub-hosted Windows, Ubuntu, and macOS runners while giving humans and workflows a durable operator path.
+
+### Read-only audit
+
+```powershell
+pwsh ./scripts/github/Repair-UpstreamForks.ps1 -AuditOnly
+```
+
+This verifies configured fork ancestry/default-branch expectations, reports Issues state, and checks common upstream contribution-policy paths. It does not mutate repositories.
+
+### Preview a mutation
+
+```powershell
+pwsh ./scripts/github/Repair-UpstreamForks.ps1 -CreateCiIssues -WhatIf
+```
+
+Mutation mode requires both `GH_TOKEN` for public reads and a separate `GH_MUTATION_TOKEN` for bounded writes. The script fails closed if mutation authority is missing.
+
+## GitHub Actions
+
+`Public-safe validation` parses all public PowerShell tooling on Windows, Ubuntu, and macOS and runs the stable fork helper in audit-only mode.
+
+`Public fork maintenance` is manual-only. Audit mode is immediately usable with the repository-scoped read-only `GITHUB_TOKEN`. Apply mode additionally requires the protected `public-ops-write` environment and a narrowly scoped GitHub App installation token.
+
+The initial mutation targets are:
+
+- `SupraCraft/VanillaCord`
+- `SupraCraft/Bridge`
+- `SemperSupra/OpenXcom`
+
+Apply must originate from `main`, requires the exact confirmation phrase `APPLY-PUBLIC-FORK-MAINTENANCE`, runs the audit first, and mints separate short-lived App tokens for the SupraCraft and SemperSupra repository subsets.
+
+## Authority boundary
+
+Do not add private-repository credentials, broad personal access tokens, private source, private fixtures, evaluator data, or restricted engineering knowledge to this public repository merely to gain runner capacity. Public execution produces evidence; it does not confer private promotion authority.

--- a/scripts/github/Repair-UpstreamForks.ps1
+++ b/scripts/github/Repair-UpstreamForks.ps1
@@ -1,0 +1,37 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+  Stable public entry point for upstream-fork audit and maintenance.
+
+.DESCRIPTION
+  This public entry point delegates to the byte-validated implementation kept in
+  candidates/Repair-UpstreamForks.ps1. It exists so operators and workflows have
+  a durable scripts/github path while the candidate remains available as the
+  exact validation/provenance object.
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [switch]$AuditOnly,
+    [switch]$CreateCiIssues,
+    [ValidateSet('SupraCraft/VanillaCord', 'SupraCraft/Bridge', 'SemperSupra/OpenXcom')]
+    [string[]]$Fork
+)
+
+$implementation = Join-Path $PSScriptRoot '..' '..' 'candidates' 'Repair-UpstreamForks.ps1'
+$implementation = [IO.Path]::GetFullPath($implementation)
+
+if (-not (Test-Path -LiteralPath $implementation -PathType Leaf)) {
+    throw "Validated implementation not found: $implementation"
+}
+
+$invoke = @{}
+if ($AuditOnly) { $invoke.AuditOnly = $true }
+if ($CreateCiIssues) { $invoke.CreateCiIssues = $true }
+if ($Fork) { $invoke.Fork = $Fork }
+if ($WhatIfPreference) { $invoke.WhatIf = $true }
+
+& $implementation @invoke
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}


### PR DESCRIPTION
## Purpose
Promote the validated upstream-fork helper from a temporary candidate-only surface into a durable public GitHub-ops entry point that humans and workflows can use immediately.

## Changes
- add `scripts/github/Repair-UpstreamForks.ps1` as the stable public operator entry point;
- retain `candidates/Repair-UpstreamForks.ps1` as the exact byte-validated/provenance implementation;
- update `Public-safe validation` to parse both candidate and stable public scripts and exercise the stable entry point;
- update `Public fork maintenance` to call the stable entry point for audit and apply;
- add `docs/public-fork-operations.md` with usage and authority boundaries.

## Current usability
Audit mode is usable immediately with normal public GitHub access. Apply remains fail-closed until the protected GitHub App/environment credentials are configured; this PR does not weaken that boundary.

Refs: #2 #4 #8