### PR TITLE
Add reusable WinPS 5.1 / PowerShell 7 compatibility validator

### DIFF
--- a/.github/workflows/powershell-compatibility-selftest.yml
+++ b/.github/workflows/powershell-compatibility-selftest.yml
@@ -1,0 +1,79 @@
+name: PowerShell compatibility self-test
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/powershell/**'
+      - 'tests/fixtures/powershell-compat/**'
+      - '.github/workflows/powershell-compatibility*.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/powershell/**'
+      - 'tests/fixtures/powershell-compat/**'
+      - '.github/workflows/powershell-compatibility*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  real-windows-engines:
+    name: Real WinPS 5.1 vs PS7
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Scan with Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          if ($PSVersionTable.PSVersion.Major -ne 5 -or $PSVersionTable.PSVersion.Minor -ne 1) {
+            throw "Expected Windows PowerShell 5.1, got $($PSVersionTable.PSVersion)"
+          }
+          ./scripts/powershell/Test-PowerShellCompatibility.ps1 -Root ./tests/fixtures/powershell-compat -OutputPath ./evidence/winps51-windows.json -Lane winps51-windows
+
+      - name: Scan with PowerShell 7
+        shell: pwsh
+        run: |
+          if ($PSVersionTable.PSVersion.Major -lt 7) { throw "Expected PowerShell 7+, got $($PSVersionTable.PSVersion)" }
+          ./scripts/powershell/Test-PowerShellCompatibility.ps1 -Root ./tests/fixtures/powershell-compat -OutputPath ./evidence/ps7-windows.json -Lane ps7-windows
+
+      - name: Prove expected compatibility distinction
+        shell: pwsh
+        run: |
+          ./scripts/powershell/Compare-PowerShellCompatibility.ps1 -ResultsRoot ./evidence -OutputPath ./evidence/comparison.json
+          $win = Get-Content ./evidence/winps51-windows.json -Raw | ConvertFrom-Json
+          $ps7 = Get-Content ./evidence/ps7-windows.json -Raw | ConvertFrom-Json
+          $comparison = Get-Content ./evidence/comparison.json -Raw | ConvertFrom-Json
+          $winCross = $win.files | Where-Object path -eq 'cross-compatible.ps1'
+          $winPs7Only = $win.files | Where-Object path -eq 'ps7-only.ps1'
+          $ps7Cross = $ps7.files | Where-Object path -eq 'cross-compatible.ps1'
+          $ps7Only = $ps7.files | Where-Object path -eq 'ps7-only.ps1'
+          if (-not $winCross.parseCompatible) { throw 'Cross-compatible fixture failed WinPS 5.1.' }
+          if ($winPs7Only.parseCompatible) { throw 'PS7-only fixture unexpectedly parsed in WinPS 5.1.' }
+          if (-not $ps7Cross.parseCompatible -or -not $ps7Only.parseCompatible) { throw 'Expected fixtures to parse in PS7.' }
+          if ($comparison.crossEngineParseFailureCount -ne 1) { throw 'Expected exactly one cross-engine parse incompatibility.' }
+
+      - name: Upload self-test evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: powershell-compat-selftest-windows
+          path: evidence/*.json
+          retention-days: 14
+
+  portable-ps7:
+    name: Portable PS7 parse (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+      - shell: pwsh
+        run: |
+          if ($PSVersionTable.PSVersion.Major -lt 7) { throw "Expected PowerShell 7+, got $($PSVersionTable.PSVersion)" }
+          ./scripts/powershell/Test-PowerShellCompatibility.ps1 -Root ./tests/fixtures/powershell-compat -OutputPath ./evidence/ps7-portable.json -Lane 'ps7-${{ matrix.os }}' -FailOnParseError

--- a/.github/workflows/powershell-compatibility.yml
+++ b/.github/workflows/powershell-compatibility.yml
@@ -78,11 +78,20 @@ jobs:
 
       - name: Scan without executing target scripts
         shell: ${{ matrix.shell }}
+        env:
+          TARGET_RELATIVE_PATH: ${{ inputs.path }}
+          LANE: ${{ matrix.lane }}
         run: |
+          $targetBase = [IO.Path]::GetFullPath((Join-Path $PWD 'target'))
+          $scanRoot = [IO.Path]::GetFullPath((Join-Path $targetBase $env:TARGET_RELATIVE_PATH))
+          $prefix = $targetBase.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+          if (($scanRoot -ne $targetBase) -and -not $scanRoot.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Requested path escapes the checked-out target repository.'
+          }
           & ./validator/scripts/powershell/Test-PowerShellCompatibility.ps1 `
-            -Root ./target/${{ inputs.path }} `
-            -OutputPath ./evidence/${{ matrix.lane }}.json `
-            -Lane '${{ matrix.lane }}'
+            -Root $scanRoot `
+            -OutputPath (Join-Path $PWD ('evidence/{0}.json' -f $env:LANE)) `
+            -Lane $env:LANE
 
       - name: Upload lane evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/powershell-compatibility.yml
+++ b/.github/workflows/powershell-compatibility.yml
@@ -1,0 +1,131 @@
+name: PowerShell compatibility
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        description: Public owner/repo to validate; empty means caller repository
+        required: false
+        type: string
+        default: ''
+      ref:
+        description: Git ref/SHA to validate; empty means caller SHA
+        required: false
+        type: string
+        default: ''
+      path:
+        description: Relative path within target repository
+        required: false
+        type: string
+        default: '.'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Public owner/repo to validate
+        required: true
+        type: string
+        default: SupraShellScripts/github-ops-lab
+      ref:
+        description: Git ref/SHA to validate
+        required: true
+        type: string
+        default: main
+      path:
+        description: Relative path within target repository
+        required: true
+        type: string
+        default: .
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: ${{ matrix.lane }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: winps51-windows
+            os: windows-latest
+            shell: powershell
+          - lane: ps7-windows
+            os: windows-latest
+            shell: pwsh
+          - lane: ps7-linux
+            os: ubuntu-latest
+            shell: pwsh
+          - lane: ps7-macos
+            os: macos-latest
+            shell: pwsh
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out validator
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          repository: SupraShellScripts/github-ops-lab
+          ref: main
+          path: validator
+          persist-credentials: false
+
+      - name: Check out public target
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          repository: ${{ inputs.repository != '' && inputs.repository || github.repository }}
+          ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+          path: target
+          persist-credentials: false
+
+      - name: Scan without executing target scripts
+        shell: ${{ matrix.shell }}
+        run: |
+          & ./validator/scripts/powershell/Test-PowerShellCompatibility.ps1 `
+            -Root ./target/${{ inputs.path }} `
+            -OutputPath ./evidence/${{ matrix.lane }}.json `
+            -Lane '${{ matrix.lane }}'
+
+      - name: Upload lane evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ps-compat-${{ matrix.lane }}
+          path: evidence/${{ matrix.lane }}.json
+          if-no-files-found: error
+          retention-days: 14
+
+  compare:
+    name: Compare WinPS 5.1 and PS7 evidence
+    needs: scan
+    if: ${{ always() && needs.scan.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out validator
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          repository: SupraShellScripts/github-ops-lab
+          ref: main
+          path: validator
+          persist-credentials: false
+
+      - name: Download lane evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: ps-compat-*
+          path: lane-evidence
+          merge-multiple: true
+
+      - name: Compare required Windows engines
+        shell: pwsh
+        run: |
+          ./validator/scripts/powershell/Compare-PowerShellCompatibility.ps1 `
+            -ResultsRoot ./lane-evidence `
+            -OutputPath ./comparison/powershell-compatibility.json `
+            -RequireWinPS51AndPS7
+
+      - name: Upload comparison evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: powershell-compatibility-comparison
+          path: comparison/powershell-compatibility.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/powershell-compatibility.md
+++ b/docs/powershell-compatibility.md
@@ -1,0 +1,64 @@
+# PowerShell compatibility validation
+
+`github-ops-lab` provides a public-safe validation service for PowerShell-heavy public repositories.
+
+## Evidence levels
+
+1. **Parse compatible** — the same source bytes are accepted by the real Windows PowerShell 5.1 parser and the real PowerShell 7 parser on GitHub-hosted Windows. Additional PS7 Linux/macOS lanes show portable parser acceptance.
+2. **Static risk reviewed** — the scanner records bounded heuristic findings for dynamic or high-impact commands. This is review assistance, not proof of safety. Absence of findings is not a safety guarantee.
+3. **Test equivalent** — reserved for a later opt-in lane where the project declares a deterministic test harness and the same tests pass under both required runtimes. Parsing alone must never be labeled behavioral equivalence.
+
+The default workflow does **not execute target scripts**.
+
+## Manual use
+
+Open Actions -> **PowerShell compatibility** -> **Run workflow** and provide:
+
+- public `owner/repo`;
+- branch, tag, or commit SHA;
+- relative path to scan, normally `.`.
+
+The workflow checks out the public target read-only and scans `.ps1`, `.psm1`, and `.psd1` files in four lanes:
+
+- real Windows PowerShell 5.1 on `windows-latest`;
+- PowerShell 7.x on Windows;
+- PowerShell 7.x on Ubuntu;
+- PowerShell 7.x on macOS.
+
+Each lane emits JSON containing runtime identity, source hashes, parser diagnostics, and heuristic findings. A comparison job verifies that the Windows 5.1 and Windows PS7 lanes examined the same bytes and reports cross-engine incompatibilities.
+
+## Reusable workflow
+
+A public repository can call:
+
+```yaml
+jobs:
+  powershell-compat:
+    uses: SupraShellScripts/github-ops-lab/.github/workflows/powershell-compatibility.yml@main
+    with:
+      path: .
+```
+
+When called from another repository, an empty `repository` input means the caller repository and an empty `ref` means the caller SHA. The caller can also supply an explicit public repository/ref.
+
+## Local scanner
+
+The scanner itself remains usable locally when the relevant engine exists:
+
+```powershell
+powershell.exe -NoProfile -File ./scripts/powershell/Test-PowerShellCompatibility.ps1 -Root . -OutputPath ./winps51.json -Lane winps51-windows
+pwsh -NoProfile -File ./scripts/powershell/Test-PowerShellCompatibility.ps1 -Root . -OutputPath ./ps7.json -Lane ps7-windows
+pwsh -NoProfile -File ./scripts/powershell/Compare-PowerShellCompatibility.ps1 -ResultsRoot . -OutputPath ./comparison.json -RequireWinPS51AndPS7
+```
+
+The public service exists specifically so projects do not need to reproduce Windows PowerShell 5.1 locally merely to obtain parser compatibility evidence.
+
+## Boundaries
+
+- public repositories only;
+- read-only target checkout;
+- no target script execution in default mode;
+- no private credentials or private source;
+- parser compatibility is not behavioral equivalence;
+- heuristic risk findings are not a safety proof;
+- Windows PowerShell 5.1 evidence comes from actual `powershell.exe` 5.1, never inferred from PS7 or a Linux container.

--- a/scripts/powershell/Compare-PowerShellCompatibility.ps1
+++ b/scripts/powershell/Compare-PowerShellCompatibility.ps1
@@ -1,0 +1,84 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$ResultsRoot,
+    [Parameter(Mandatory=$true)][string]$OutputPath,
+    [switch]$RequireWinPS51AndPS7
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$documents = @{}
+Get-ChildItem -LiteralPath $ResultsRoot -Recurse -Filter '*.json' -File | ForEach-Object {
+    $doc = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
+    if ($doc.runtime -and $doc.runtime.lane) {
+        $documents[[string]$doc.runtime.lane] = $doc
+    }
+}
+
+$required = @('winps51-windows','ps7-windows')
+$missing = @($required | Where-Object { -not $documents.ContainsKey($_) })
+if ($RequireWinPS51AndPS7 -and $missing.Count -gt 0) {
+    throw ('Missing required lane evidence: ' + ($missing -join ', '))
+}
+
+$allPaths = @($documents.Values | ForEach-Object { $_.files | ForEach-Object { $_.path } } | Sort-Object -Unique)
+$rows = @()
+foreach ($path in $allPaths) {
+    $laneStates = [ordered]@{}
+    foreach ($lane in @($documents.Keys | Sort-Object)) {
+        $entry = @($documents[$lane].files | Where-Object { $_.path -eq $path }) | Select-Object -First 1
+        if ($entry) {
+            $laneStates[$lane] = [ordered]@{
+                sha256 = $entry.sha256
+                parseCompatible = [bool]$entry.parseCompatible
+                diagnosticCount = @($entry.parserDiagnostics).Count
+                heuristicFindingCount = @($entry.riskHeuristics).Count
+            }
+        }
+    }
+
+    $win = if ($documents.ContainsKey('winps51-windows')) { @($documents['winps51-windows'].files | Where-Object { $_.path -eq $path }) | Select-Object -First 1 } else { $null }
+    $ps7 = if ($documents.ContainsKey('ps7-windows')) { @($documents['ps7-windows'].files | Where-Object { $_.path -eq $path }) | Select-Object -First 1 } else { $null }
+    $crossEngine = $null
+    if ($win -and $ps7) { $crossEngine = ([bool]$win.parseCompatible -and [bool]$ps7.parseCompatible) }
+
+    $rows += [ordered]@{
+        path = $path
+        crossEngineParseCompatible = $crossEngine
+        lanes = $laneStates
+    }
+}
+
+$crossEngineFailures = @($rows | Where-Object { $_.crossEngineParseCompatible -eq $false })
+$hashDrift = @()
+foreach ($row in $rows) {
+    $hashes = @($row.lanes.Values | ForEach-Object { $_.sha256 } | Sort-Object -Unique)
+    if ($hashes.Count -gt 1) { $hashDrift += $row.path }
+}
+
+$result = [ordered]@{
+    schemaVersion = '1.0'
+    generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+    evidenceLevel = if ($crossEngineFailures.Count -eq 0 -and $missing.Count -eq 0) { 'parse-compatible' } else { 'incompatible-or-incomplete' }
+    behavioralEquivalence = 'not-evaluated'
+    requiredLanes = $required
+    missingRequiredLanes = $missing
+    crossEngineParseFailureCount = $crossEngineFailures.Count
+    sourceHashDrift = $hashDrift
+    files = $rows
+    semantics = [ordered]@{
+        parseCompatible = 'Both real Windows PowerShell 5.1 and PowerShell 7 Windows parsers accepted the same source bytes.'
+        behavioralEquivalence = 'Requires project-declared tests executed in both engines; this report does not infer it from parsing.'
+        safety = 'Heuristic findings require review and do not constitute a safety proof.'
+    }
+}
+
+$outputDir = Split-Path -Parent $OutputPath
+if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -Path $outputDir -Force | Out-Null }
+$result | ConvertTo-Json -Depth 14 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+
+Write-Host ('Evidence level: {0}; cross-engine parse failures: {1}; missing lanes: {2}' -f $result.evidenceLevel, $result.crossEngineParseFailureCount, $result.missingRequiredLanes.Count)
+if ($result.sourceHashDrift.Count -gt 0) { throw ('Source hash drift across lanes: ' + ($result.sourceHashDrift -join ', ')) }
+if ($RequireWinPS51AndPS7 -and ($result.crossEngineParseFailureCount -gt 0 -or $result.missingRequiredLanes.Count -gt 0)) { exit 2 }
+exit 0

--- a/scripts/powershell/Test-PowerShellCompatibility.ps1
+++ b/scripts/powershell/Test-PowerShellCompatibility.ps1
@@ -2,7 +2,8 @@
 param(
     [Parameter(Mandatory=$true)][string]$Root,
     [Parameter(Mandatory=$true)][string]$OutputPath,
-    [string]$Lane = 'unknown'
+    [string]$Lane = 'unknown',
+    [switch]$FailOnParseError
 )
 
 Set-StrictMode -Version 2.0
@@ -18,18 +19,9 @@ $runtime = [ordered]@{
 }
 
 $riskyCommands = @(
-    'Invoke-Expression',
-    'Add-Type',
-    'Start-Process',
-    'Invoke-WebRequest',
-    'Invoke-RestMethod',
-    'Start-BitsTransfer',
-    'Register-ScheduledTask',
-    'New-ScheduledTaskAction',
-    'Set-ExecutionPolicy',
-    'Set-ItemProperty',
-    'Remove-Item',
-    'Remove-ItemProperty'
+    'Invoke-Expression','Add-Type','Start-Process','Invoke-WebRequest','Invoke-RestMethod',
+    'Start-BitsTransfer','Register-ScheduledTask','New-ScheduledTaskAction','Set-ExecutionPolicy',
+    'Set-ItemProperty','Remove-Item','Remove-ItemProperty'
 )
 
 $files = @(Get-ChildItem -LiteralPath $resolvedRoot -Recurse -File | Where-Object {
@@ -41,18 +33,14 @@ foreach ($file in $files) {
     $tokens = $null
     $errors = $null
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$tokens, [ref]$errors)
-
     $relative = $file.FullName.Substring($resolvedRoot.Length).TrimStart([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
     $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
 
     $diagnostics = @($errors | ForEach-Object {
         [ordered]@{
-            message = $_.Message
-            errorId = $_.ErrorId
-            startLine = $_.Extent.StartLineNumber
-            startColumn = $_.Extent.StartColumnNumber
-            endLine = $_.Extent.EndLineNumber
-            endColumn = $_.Extent.EndColumnNumber
+            message = $_.Message; errorId = $_.ErrorId
+            startLine = $_.Extent.StartLineNumber; startColumn = $_.Extent.StartColumnNumber
+            endLine = $_.Extent.EndLineNumber; endColumn = $_.Extent.EndColumnNumber
             text = $_.Extent.Text
         }
     })
@@ -62,20 +50,10 @@ foreach ($file in $files) {
     foreach ($command in $commands) {
         $name = $command.GetCommandName()
         if ($name -and ($name -in $riskyCommands)) {
-            $risks += [ordered]@{
-                kind = 'command-heuristic'
-                command = $name
-                line = $command.Extent.StartLineNumber
-                note = 'Review required; heuristic finding is not proof of unsafe behavior.'
-            }
+            $risks += [ordered]@{ kind='command-heuristic'; command=$name; line=$command.Extent.StartLineNumber; note='Review required; heuristic finding is not proof of unsafe behavior.' }
         }
         if (-not $name) {
-            $risks += [ordered]@{
-                kind = 'dynamic-command'
-                command = $null
-                line = $command.Extent.StartLineNumber
-                note = 'Dynamic command invocation reduces static assurance.'
-            }
+            $risks += [ordered]@{ kind='dynamic-command'; command=$null; line=$command.Extent.StartLineNumber; note='Dynamic command invocation reduces static assurance.' }
         }
     }
 
@@ -106,11 +84,8 @@ $document = [ordered]@{
 }
 
 $outputDir = Split-Path -Parent $OutputPath
-if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) {
-    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
-}
+if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) { New-Item -ItemType Directory -Path $outputDir -Force | Out-Null }
 $document | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
-
 Write-Host ('Lane: {0}; files: {1}; parse failures: {2}; heuristic findings: {3}' -f $Lane, $document.fileCount, $document.parseFailCount, $document.heuristicFindingCount)
-if ($document.parseFailCount -gt 0) { exit 2 }
+if ($FailOnParseError -and $document.parseFailCount -gt 0) { exit 2 }
 exit 0

--- a/scripts/powershell/Test-PowerShellCompatibility.ps1
+++ b/scripts/powershell/Test-PowerShellCompatibility.ps1
@@ -1,0 +1,116 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Root,
+    [Parameter(Mandatory=$true)][string]$OutputPath,
+    [string]$Lane = 'unknown'
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$resolvedRoot = (Resolve-Path -LiteralPath $Root).Path
+$runtime = [ordered]@{
+    lane = $Lane
+    psVersion = $PSVersionTable.PSVersion.ToString()
+    psEdition = if ($PSVersionTable.ContainsKey('PSEdition')) { [string]$PSVersionTable.PSEdition } else { 'Desktop' }
+    platform = if ($PSVersionTable.ContainsKey('Platform')) { [string]$PSVersionTable.Platform } else { 'Win32NT' }
+    os = if ($PSVersionTable.ContainsKey('OS')) { [string]$PSVersionTable.OS } else { [Environment]::OSVersion.VersionString }
+}
+
+$riskyCommands = @(
+    'Invoke-Expression',
+    'Add-Type',
+    'Start-Process',
+    'Invoke-WebRequest',
+    'Invoke-RestMethod',
+    'Start-BitsTransfer',
+    'Register-ScheduledTask',
+    'New-ScheduledTaskAction',
+    'Set-ExecutionPolicy',
+    'Set-ItemProperty',
+    'Remove-Item',
+    'Remove-ItemProperty'
+)
+
+$files = @(Get-ChildItem -LiteralPath $resolvedRoot -Recurse -File | Where-Object {
+    $_.Extension -in @('.ps1','.psm1','.psd1')
+} | Sort-Object FullName)
+
+$results = @()
+foreach ($file in $files) {
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$tokens, [ref]$errors)
+
+    $relative = $file.FullName.Substring($resolvedRoot.Length).TrimStart([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    $diagnostics = @($errors | ForEach-Object {
+        [ordered]@{
+            message = $_.Message
+            errorId = $_.ErrorId
+            startLine = $_.Extent.StartLineNumber
+            startColumn = $_.Extent.StartColumnNumber
+            endLine = $_.Extent.EndLineNumber
+            endColumn = $_.Extent.EndColumnNumber
+            text = $_.Extent.Text
+        }
+    })
+
+    $risks = @()
+    $commands = @($ast.FindAll({ param($node) $node -is [System.Management.Automation.Language.CommandAst] }, $true))
+    foreach ($command in $commands) {
+        $name = $command.GetCommandName()
+        if ($name -and ($name -in $riskyCommands)) {
+            $risks += [ordered]@{
+                kind = 'command-heuristic'
+                command = $name
+                line = $command.Extent.StartLineNumber
+                note = 'Review required; heuristic finding is not proof of unsafe behavior.'
+            }
+        }
+        if (-not $name) {
+            $risks += [ordered]@{
+                kind = 'dynamic-command'
+                command = $null
+                line = $command.Extent.StartLineNumber
+                note = 'Dynamic command invocation reduces static assurance.'
+            }
+        }
+    }
+
+    $results += [ordered]@{
+        path = ($relative -replace '\\','/')
+        sha256 = $hash
+        parseCompatible = ($diagnostics.Count -eq 0)
+        parserDiagnostics = $diagnostics
+        riskHeuristics = $risks
+    }
+}
+
+$document = [ordered]@{
+    schemaVersion = '1.0'
+    generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+    root = $resolvedRoot
+    runtime = $runtime
+    fileCount = $results.Count
+    parsePassCount = @($results | Where-Object { $_.parseCompatible }).Count
+    parseFailCount = @($results | Where-Object { -not $_.parseCompatible }).Count
+    heuristicFindingCount = (@($results | ForEach-Object { $_.riskHeuristics })).Count
+    files = $results
+    semantics = [ordered]@{
+        parseCompatibility = 'Evidence that this runtime parser accepted the source.'
+        safety = 'Risk findings are heuristics only; absence of findings is not a safety proof.'
+        behavioralEquivalence = 'Not evaluated by this scanner.'
+    }
+}
+
+$outputDir = Split-Path -Parent $OutputPath
+if ($outputDir -and -not (Test-Path -LiteralPath $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+$document | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+
+Write-Host ('Lane: {0}; files: {1}; parse failures: {2}; heuristic findings: {3}' -f $Lane, $document.fileCount, $document.parseFailCount, $document.heuristicFindingCount)
+if ($document.parseFailCount -gt 0) { exit 2 }
+exit 0

--- a/tests/fixtures/powershell-compat/cross-compatible.ps1
+++ b/tests/fixtures/powershell-compat/cross-compatible.ps1
@@ -1,0 +1,6 @@
+param([string]$Name = 'world')
+
+$items = @('WindowsPowerShell51', 'PowerShell7')
+foreach ($item in $items) {
+    Write-Output ("{0}: hello {1}" -f $item, $Name)
+}

--- a/tests/fixtures/powershell-compat/ps7-only.ps1
+++ b/tests/fixtures/powershell-compat/ps7-only.ps1
@@ -1,0 +1,2 @@
+$value = $true ? 'ps7' : 'legacy'
+Write-Output $value


### PR DESCRIPTION
## Purpose
Implement issue #13: a public GitHub-hosted PowerShell compatibility service so public projects can obtain real Windows PowerShell 5.1 and PowerShell 7 parser evidence without first reproducing those runtimes locally.

## What this adds
- PS5.1-compatible scanner for `.ps1`, `.psm1`, and `.psd1` files;
- real runtime identity + SHA-256 source identity + parser diagnostics in JSON;
- bounded static risk heuristics, explicitly not presented as a safety proof;
- deterministic comparison of WinPS 5.1 and Windows PS7 evidence;
- reusable/manual workflow targeting arbitrary public repository/ref/path;
- Windows PowerShell 5.1, PS7 Windows, PS7 Ubuntu, and PS7 macOS lanes;
- self-test fixtures proving a real PS7-only syntax distinction;
- documentation of parse-compatible vs static-risk-reviewed vs future test-equivalent evidence.

## Safety posture
Default validation never executes target scripts. Target checkout is read-only. The relative scan path is normalized and rejected if it escapes the checked-out target tree. No private credentials or private source are accepted.

## Semantic boundary
Parser compatibility is not behavioral equivalence. Behavioral equivalence will require an explicit project-owned test harness to pass under both real required runtimes. WinPS 5.1 evidence comes only from actual `powershell.exe` 5.1.

Closes #13 when accepted.