### PR TITLE
Adopt constrained public security validation stack

### DIFF
--- a/.github/workflows/public-fork-maintenance.yml
+++ b/.github/workflows/public-fork-maintenance.yml
@@ -39,9 +39,12 @@ jobs:
       - name: Require main and confirmation for apply
         if: ${{ inputs.mode == 'apply' }}
         shell: pwsh
+        env:
+          REQUEST_REF: ${{ github.ref }}
+          APPLY_CONFIRMATION: ${{ inputs.confirmation }}
         run: |
-          if ('${{ github.ref }}' -ne 'refs/heads/main') { throw 'Apply is permitted only from refs/heads/main.' }
-          if ('${{ inputs.confirmation }}' -ne 'APPLY-PUBLIC-FORK-MAINTENANCE') { throw 'Apply confirmation phrase does not match.' }
+          if ($env:REQUEST_REF -ne 'refs/heads/main') { throw 'Apply is permitted only from refs/heads/main.' }
+          if ($env:APPLY_CONFIRMATION -ne 'APPLY-PUBLIC-FORK-MAINTENANCE') { throw 'Apply confirmation phrase does not match.' }
 
       - name: Run read-only audit
         shell: pwsh
@@ -72,6 +75,8 @@ jobs:
           repositories: |
             VanillaCord
             Bridge
+          permission-administration: write
+          permission-issues: write
 
       - name: Apply validated SupraCraft maintenance
         shell: pwsh
@@ -105,6 +110,8 @@ jobs:
           private-key: ${{ secrets.PUBLIC_OPS_APP_PRIVATE_KEY }}
           owner: SemperSupra
           repositories: OpenXcom
+          permission-administration: write
+          permission-issues: write
 
       - name: Apply validated SemperSupra maintenance
         shell: pwsh

--- a/.github/workflows/public-security-validation.yml
+++ b/.github/workflows/public-security-validation.yml
@@ -28,6 +28,7 @@ jobs:
           annotations: true
           min-severity: low
           min-confidence: medium
+          version: 1.29.0
 
   scorecard:
     name: OpenSSF Scorecard
@@ -53,13 +54,3 @@ jobs:
           path: results.sarif
           if-no-files-found: error
           retention-days: 14
-
-  dependency-review:
-    name: Dependency review
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Review dependency changes
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
-        with:
-          fail-on-severity: high

--- a/.github/workflows/public-security-validation.yml
+++ b/.github/workflows/public-security-validation.yml
@@ -15,9 +15,6 @@ jobs:
   zizmor:
     name: GitHub Actions security (zizmor)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
     steps:
       - name: Check out exact revision
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -25,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Audit GitHub Actions
-        uses: zizmorcore/zizmor-action@3dc1ecc8f1c2af622d7a6b1c4dd434777f816650
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           advanced-security: false
           annotations: true
@@ -36,10 +33,6 @@ jobs:
     name: OpenSSF Scorecard
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      id-token: write
     steps:
       - name: Check out exact revision
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -47,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -65,10 +58,8 @@ jobs:
     name: Dependency review
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Review dependency changes
-        uses: actions/dependency-review-action@a1d282b36d1f4f7fe2ca53834424ff1f28750e2f
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high

--- a/.github/workflows/public-security-validation.yml
+++ b/.github/workflows/public-security-validation.yml
@@ -1,0 +1,74 @@
+name: Public security validation
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: GitHub Actions security (zizmor)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Audit GitHub Actions
+        uses: zizmorcore/zizmor-action@3dc1ecc8f1c2af622d7a6b1c4dd434777f816650
+        with:
+          advanced-security: false
+          annotations: true
+          min-severity: low
+          min-confidence: medium
+
+  scorecard:
+    name: OpenSSF Scorecard
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload Scorecard SARIF as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          if-no-files-found: error
+          retention-days: 14
+
+  dependency-review:
+    name: Dependency review
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36d1f4f7fe2ca53834424ff1f28750e2f
+        with:
+          fail-on-severity: high

--- a/docs/adoption-candidates.md
+++ b/docs/adoption-candidates.md
@@ -1,0 +1,119 @@
+# Public validation adoption candidates
+
+## Scope
+
+This survey asks where the lab's proven validation capabilities are likely to reduce real engineering risk or local-agent work across active public repositories. It intentionally does not recommend blanket rollout.
+
+The ranking considers:
+
+- active public repository rather than private/archived state;
+- amount and sensitivity of custom GitHub Actions surface;
+- build/release/package responsibilities;
+- PowerShell content that benefits from real WinPS 5.1 / PowerShell 7 evidence;
+- dependency-manifest churn where dependency review can add value;
+- fork status and upstream-divergence cost;
+- whether a CI modernization issue already exists and can absorb the work without issue sprawl.
+
+## Tier 1 — immediate pilots
+
+### `SemperSupra/windows-package-foundry`
+
+**Payoff: very high.** It currently has three custom workflows, including release-trust and WinInspect lifecycle/readiness workflows, plus repository-local `actions/`, `scripts/`, and `tests/` surfaces.
+
+Recommended composition:
+
+- zizmor on workflow/action changes and default-branch scheduled scans;
+- OpenSSF Scorecard on push/schedule;
+- existing github-ops-lab WinPS 5.1 / PowerShell 7 validation for PowerShell source;
+- dependency review only if/when a supported dependency graph has meaningful dependency manifests;
+- later artifact attestation/SBOM work belongs in the Foundry release design rather than this generic lab.
+
+Track through existing `SemperSupra/windows-package-foundry#15`; do not create a duplicate adoption issue.
+
+### `SemperSupra/WinInspect`
+
+**Payoff: very high.** The public repo currently has projected-source CI plus a substantial release workflow. Release automation has higher consequence than ordinary test-only CI, so workflow security scanning has a favorable signal-to-noise ratio.
+
+Recommended composition:
+
+- zizmor immediately;
+- Scorecard push/schedule posture evidence;
+- PowerShell compatibility where projected public PowerShell is part of the release surface;
+- dependency review where supported;
+- retain deeper release/provenance/SBOM work under the existing Foundry/governance model.
+
+Track through existing `SemperSupra/WinInspect#11`.
+
+### `SemperSupra/truenas-app-foundry`
+
+**Payoff: very high.** It currently carries five custom workflows spanning appliance build, qualification, base validation, materialization validation, and source-contract validation. This is exactly the kind of workflow-heavy build system where an independent workflow-security validator is useful.
+
+Recommended composition:
+
+- zizmor immediately;
+- Scorecard push/schedule;
+- dependency review when a supported dependency graph is present;
+- keep TrueNAS-specific lifecycle and artifact validation in the project/Foundry rather than centralizing it here.
+
+Track through existing `SemperSupra/truenas-app-foundry#21`.
+
+## Tier 2 — high-confidence follow-ons after the three pilots
+
+### `SemperSupra/garm-provider-truenas`
+
+One substantial CI workflow and a Go/upstream-compatibility surface make zizmor + Scorecard low-cost. Dependency review is useful if the Go module graph is enabled. Track through existing `#18`.
+
+### `SupraShellScripts/userscripts`
+
+A public artifact-verification workflow exists. Zizmor is cheap and dependency review becomes useful as the Node/toolchain surface expands. Track through existing `#5`.
+
+### `SemperSupra/DE2-115`
+
+Hardware/HDL work has expensive feedback loops, so public workflow posture checks are useful where GitHub Actions can catch issues before hardware/local-tool execution. Adopt zizmor/Scorecard as lightweight outer checks; do not pretend they replace FPGA/toolchain validation. Track through existing `#66`.
+
+### `SemperSupra/AgentKVM2USB`
+
+Similar rationale to DE2-115: inexpensive workflow/security evidence can protect the public build/test surface while hardware-specific correctness remains elsewhere. Track through existing `#37`.
+
+### `SemperSupra/SupraBlueSniffer`
+
+Public build/API/synthetic-test work is already planned. Add the lightweight repository/workflow checks as part of existing `#1`, not as a separate program.
+
+## Tier 3 — adopt when their CI surface matures
+
+`SemperSupra/BrowserParity`, `SupraShellScripts/violentmonkey-workbench`, `mark-e-deyoung/secure-messaging`, `SemperSupra/oxce-mod-studio`, `SemperSupra/scrutari`, `SemperSupra/supragoflow`, and `SemperSupra/EvoForge` already have CI-oriented work items, but some currently have little or no public workflow surface. Add the baseline as those CI implementations become real rather than creating empty security workflows in advance.
+
+## Special case — `SupraShellScripts/violentmonkey`
+
+The fork already carries multiple upstream-derived CI, release, store-download, and translation workflows, so zizmor could find meaningful workflow issues. However this is an upstream-oriented maintained fork. Do not inject generic downstream CI merely because it is available. First distinguish inherited upstream findings from fork-introduced findings and keep any fork-only workflow changes narrowly justified.
+
+Dependency review may be useful for the Node dependency graph. Scorecard is not an adoption candidate while the repository remains a fork because the Scorecard action does not support fork repositories.
+
+## Forks: audit, do not standardize blindly
+
+`SupraCraft/VanillaCord`, `SupraCraft/Bridge`, and `SemperSupra/OpenXcom` should not receive the same blanket stack as independent repositories. Scorecard is not supported for fork repositories. Zizmor is useful only where a meaningful workflow surface exists and should be used first as an audit, with upstream-vs-fork differences classified before changing the fork.
+
+Their existing fork-maintenance/CI work items remain the coordination surface.
+
+## No-current-payoff / defer
+
+Do not add validation plumbing merely to make a repository look standardized when there is little for it to validate. Defer empty or near-empty public projections such as `SemperSupra/playnite-auto-report`, `SemperSupra/mcp-projection`, `SupraShellScripts/stateless-dev-tooling`, and similarly thin deployment shells until their public execution surface exists.
+
+Simple static sites and legacy/archived repositories are also outside the initial rollout unless they resume active development.
+
+## Dependency review rule
+
+Dependency review is a **consumer-repository capability**, not a universal github-ops-lab broker. GitHub requires the dependency graph to be enabled. The lab self-test demonstrated that an otherwise-valid public repository can have that prerequisite disabled, in which case the action correctly refuses to run.
+
+For active Node, Go, Maven/Gradle, Python, or other supported ecosystems with meaningful PR dependency changes, enable the graph and adopt the dependency-review action directly in that repository. Do not hide an unsupported configuration behind `continue-on-error`.
+
+## Pilot success criteria
+
+Run the Tier-1 pilots before broader adoption. Continue rollout only if the evidence shows at least one of:
+
+- real workflow/security defect found;
+- release/build risk reduced;
+- local/manual review eliminated or materially shortened;
+- reusable configuration with little project-specific code.
+
+If the checks mostly generate accepted noise or require repeated project-specific suppression, stop the rollout and keep the lab as an on-demand audit surface instead.

--- a/docs/validation-strategy.md
+++ b/docs/validation-strategy.md
@@ -1,0 +1,73 @@
+# Public validation strategy
+
+## Purpose
+
+`github-ops-lab` is a public proving ground and execution substrate for deterministic validation that benefits from GitHub-hosted runners. It is not intended to become a bespoke CI/security platform or a central source of broad portfolio authority.
+
+## Decision
+
+Prefer maintained upstream tools over custom implementations. Add custom code only when a demonstrated portfolio requirement is not adequately covered by maintained public tooling.
+
+The near-term baseline is:
+
+- PowerShell compatibility: the existing real Windows PowerShell 5.1 / PowerShell 7 validator;
+- GitHub Actions/workflow security: `zizmor`;
+- repository security posture: OpenSSF Scorecard;
+- pull-request dependency risk: GitHub `dependency-review-action`;
+- portfolio-specific fork/repository topology: the existing bounded `gh` helper.
+
+`actionlint` remains a candidate only if experiment evidence shows useful findings not already covered by GitHub workflow parsing and zizmor.
+
+## Authority boundary
+
+Public validation produces evidence. It does not grant private promotion, merge, release, deployment, or cross-repository mutation authority.
+
+Default validation:
+
+- uses public inputs only;
+- uses least-privilege `GITHUB_TOKEN` permissions;
+- pins third-party Actions to immutable commit SHAs;
+- does not receive credentials that can read private repositories;
+- does not execute arbitrary target project code merely to inspect it;
+- does not convert absence of findings into a proof of safety.
+
+Any cross-repository mutation remains a separately designed, manual, bounded, protected operation.
+
+## Explicit non-goals for this phase
+
+Do not build or import, merely because it is technically possible:
+
+- a custom general GitHub Actions security scanner;
+- a bespoke SLSA/provenance implementation when GitHub-native attestations suffice;
+- a generalized clean-room execution framework;
+- a central multi-project orchestration platform;
+- a private-to-public projection exporter;
+- broad personal/org mutation credentials;
+- a duplicate SBOM ecosystem where maintained standard tools can be integrated instead.
+
+## Experiment and stop rule
+
+Adopt the baseline against representative public repositories and measure:
+
+1. meaningful defects found;
+2. local-agent or local-workstation work avoided;
+3. reuse with little project-specific customization;
+4. maintenance burden compared with benefit.
+
+If the stack mostly produces noise, duplicates existing CI, or becomes expensive to maintain, stop generalizing it.
+
+## Graduation rule
+
+The lab is the place to experiment, qualify, compare, and collect evidence. A capability that becomes stable and broadly consumed should graduate to a durable shared public tooling home rather than turning this repository into an increasingly critical monolith.
+
+## Evidence semantics
+
+Different checks establish different claims:
+
+- parser/runtime compatibility establishes compatibility evidence, not behavioral equivalence;
+- static workflow/security findings identify risk patterns, not exploitability;
+- Scorecard reports repository/supply-chain posture, not overall correctness;
+- dependency review evaluates dependency deltas, not the whole dependency graph in isolation;
+- SBOM/provenance/attestation establishes identity and origin relationships, not artifact safety.
+
+Consumers and private governance decide how those evidence products affect promotion or release decisions.

--- a/docs/validation-strategy.md
+++ b/docs/validation-strategy.md
@@ -13,10 +13,12 @@ The near-term baseline is:
 - PowerShell compatibility: the existing real Windows PowerShell 5.1 / PowerShell 7 validator;
 - GitHub Actions/workflow security: `zizmor`;
 - repository security posture: OpenSSF Scorecard;
-- pull-request dependency risk: GitHub `dependency-review-action`;
+- pull-request dependency risk: GitHub `dependency-review-action`, adopted directly in consumer repositories where GitHub Dependency Graph is enabled;
 - portfolio-specific fork/repository topology: the existing bounded `gh` helper.
 
 `actionlint` remains a candidate only if experiment evidence shows useful findings not already covered by GitHub workflow parsing and zizmor.
+
+The lab does not wrap every upstream validator merely for centralization. The first dependency-review self-test proved that this repository currently has Dependency Graph disabled; GitHub's action correctly fails as unsupported in that state. Rather than weaken failure semantics with `continue-on-error`, dependency review stays a direct consumer capability and is enabled only where its prerequisite is present.
 
 ## Authority boundary
 
@@ -27,11 +29,12 @@ Default validation:
 - uses public inputs only;
 - uses least-privilege `GITHUB_TOKEN` permissions;
 - pins third-party Actions to immutable commit SHAs;
+- pins tool versions where an Action otherwise selects a floating tool release;
 - does not receive credentials that can read private repositories;
 - does not execute arbitrary target project code merely to inspect it;
 - does not convert absence of findings into a proof of safety.
 
-Any cross-repository mutation remains a separately designed, manual, bounded, protected operation.
+Any cross-repository mutation remains a separately designed, manual, bounded, protected operation. When GitHub App tokens are required, both repository selection and requested installation-token permissions are explicitly narrowed.
 
 ## Explicit non-goals for this phase
 


### PR DESCRIPTION
## Purpose
Implement #15 by documenting the constrained lab mission and adopting maintained public validators before building more custom security/supply-chain machinery.

## Final scope
- add generic validation-strategy documentation with authority, non-goals, experiment/stop rule, graduation rule, and evidence semantics;
- add public security validation using pinned zizmor and OpenSSF Scorecard;
- pin tool/action identities rather than accepting floating defaults;
- keep ordinary workflow authority read-only;
- treat dependency review as a direct consumer-repository capability where its prerequisites exist;
- harden the manual public-fork maintenance path based on real validator findings;
- avoid publishing portfolio rankings, private source identities, or private control-plane relationships.

## Evidence from self-validation
The first workflow-security run found real template-expansion/code-injection seams and token-scope warnings. The injection seams were repaired by moving dispatch values through environment variables and token permissions were narrowed to the exact operations required.

## Rollout rule
Use synthetic fixtures and deliberately selected public consumers. Broader adoption remains conditional on finding meaningful defects or reducing review effort; estate-wide prioritization belongs outside this public repository.

## Boundary
This does not add broad mutation authority, custom SLSA machinery, private credentials, or a generalized portfolio orchestration framework.

Closes #15 when merged.