### PR TITLE
Generate derived public validation consumer inventory

### DIFF
--- a/.github/workflows/public-consumer-inventory.yml
+++ b/.github/workflows/public-consumer-inventory.yml
@@ -1,0 +1,80 @@
+name: Public validation consumer inventory
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/github/Get-PublicValidationConsumers.ps1'
+      - 'tests/fixtures/consumer-inventory/**'
+      - '.github/workflows/public-consumer-inventory.yml'
+      - 'docs/consumer-inventory.md'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/github/Get-PublicValidationConsumers.ps1'
+      - 'tests/fixtures/consumer-inventory/**'
+      - '.github/workflows/public-consumer-inventory.yml'
+      - 'docs/consumer-inventory.md'
+  schedule:
+    - cron: '41 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    name: Inventory parser self-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Generate fixture inventory
+        shell: pwsh
+        run: ./scripts/github/Get-PublicValidationConsumers.ps1 -FixtureRoot ./tests/fixtures/consumer-inventory -OutputDirectory ./out-fixture
+
+      - name: Prove detection and conservative classification
+        shell: pwsh
+        run: |
+          $doc = Get-Content ./out-fixture/public-validation-consumers.json -Raw | ConvertFrom-Json
+          if ($doc.authority -ne 'derived-non-authoritative') { throw 'Authority marker missing.' }
+          if (@($doc.relationships).Count -ne 6) { throw "Expected 6 relationships, got $(@($doc.relationships).Count)." }
+          if (@($doc.relationships | Where-Object capability -eq 'github-actions-security').Count -ne 1) { throw 'zizmor capability not detected.' }
+          if (@($doc.relationships | Where-Object capability -eq 'repository-security-posture').Count -ne 1) { throw 'Scorecard capability not detected.' }
+          if (@($doc.relationships | Where-Object capability -eq 'dependency-review').Count -ne 1) { throw 'Dependency review capability not detected.' }
+          if (@($doc.relationships | Where-Object capability -eq 'powershell-compatibility').Count -ne 1) { throw 'PowerShell compatibility capability not detected.' }
+          if (@($doc.relationships | Where-Object pinStatus -eq 'immutable-sha').Count -ne 3) { throw 'Immutable SHA classification mismatch.' }
+          if (@($doc.relationships | Where-Object pinStatus -eq 'mutable-ref').Count -ne 2) { throw 'Mutable ref classification mismatch.' }
+          $ambiguous = @($doc.relationships | Where-Object observation -eq 'ambiguous-not-asserted')
+          if ($ambiguous.Count -ne 1) { throw 'Ambiguous uses reference was not conservatively classified.' }
+
+  portfolio:
+    name: Generate public portfolio observation
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: selftest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Generate derived inventory
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/github/Get-PublicValidationConsumers.ps1 -OutputDirectory ./out
+
+      - name: Publish report to step summary
+        shell: bash
+        run: cat ./out/public-validation-consumers.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload derived evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: public-validation-consumer-inventory
+          path: out/
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/consumer-inventory.md
+++ b/docs/consumer-inventory.md
@@ -1,0 +1,46 @@
+# Derived consumer inventory
+
+`github-ops-lab` does not maintain an authoritative registry of consumer repositories.
+
+The authoritative statement of what a repository runs is the consumer repository itself, especially its `.github/workflows` files. This lab only derives an observation of those public relationships so humans and automation can answer portfolio-level questions without duplicating configuration.
+
+## Authority
+
+The generated inventory is explicitly labeled `derived-non-authoritative`.
+
+If the generated report disagrees with a consumer repository, the consumer repository wins and the inventory should be regenerated or the scanner corrected. Adding, removing, or changing a consumer workflow must not require a synchronized change in this repository.
+
+## What is observed
+
+The scanner discovers public repositories for the bounded owner set and reads workflow YAML as text. It records literal `uses:` references, including:
+
+- repository and workflow path;
+- action or reusable-workflow reference;
+- known capability classification;
+- whether the reference is pinned to a full 40-character Git commit SHA;
+- whether the relationship is directly observed or ambiguous.
+
+Known capabilities currently include zizmor, OpenSSF Scorecard, GitHub dependency review, the lab PowerShell compatibility workflow, and the public fork-maintenance workflow.
+
+The scanner also reports other action/reusable-workflow references because pinning posture is useful portfolio evidence even when the action is not one of the lab's named capabilities.
+
+## Conservative semantics
+
+A dynamic or expression-bearing `uses:` value is recorded as `ambiguous-not-asserted`. The scanner does not claim it has resolved a relationship it cannot determine from repository text.
+
+This is intentionally not a full YAML evaluator. It is a deterministic observer for the workflow forms GitHub accepts for action and reusable-workflow references. If future workflow syntax cannot be interpreted safely, the scanner should expose uncertainty rather than guess.
+
+## Outputs
+
+The workflow produces:
+
+- `public-validation-consumers.json` — canonical machine-readable observation;
+- `public-validation-consumers.md` — concise human report and job summary.
+
+The generated files are workflow artifacts, not hand-edited repository state. Regenerate them from current public repositories when a fresh portfolio view is needed.
+
+## Exceptions and intent
+
+Do not create a central consumer list just to document facts already visible in workflows.
+
+A future exceptions/intent file is justified only for facts that cannot be inferred, such as an explicit decision not to use a capability because a repository is an upstream fork. Such a file should remain small and must not duplicate detected workflow configuration.

--- a/scripts/github/Get-PublicValidationConsumers.ps1
+++ b/scripts/github/Get-PublicValidationConsumers.ps1
@@ -1,0 +1,170 @@
+[CmdletBinding()]
+param(
+    [string[]]$Owners = @('SemperSupra', 'SupraShellScripts', 'SupraCraft', 'mark-e-deyoung'),
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDirectory,
+    [string]$FixtureRoot
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+function Get-Capability {
+    param([Parameter(Mandatory = $true)][string]$Reference)
+
+    $value = $Reference.ToLowerInvariant()
+    if ($value -match '^zizmorcore/zizmor-action@') { return 'github-actions-security' }
+    if ($value -match '^ossf/scorecard-action@') { return 'repository-security-posture' }
+    if ($value -match '^actions/dependency-review-action@') { return 'dependency-review' }
+    if ($value -match '^suprashellscripts/github-ops-lab/.github/workflows/powershell-compatibility\.ya?ml@') { return 'powershell-compatibility' }
+    if ($value -match '^suprashellscripts/github-ops-lab/.github/workflows/public-fork-maintenance\.ya?ml@') { return 'fork-maintenance' }
+    return 'other-action-or-workflow'
+}
+
+function Get-PinStatus {
+    param([Parameter(Mandatory = $true)][string]$Reference)
+
+    if ($Reference -match '\$\{\{') { return 'dynamic-or-ambiguous' }
+    if ($Reference -notmatch '@([^\s#]+)$') { return 'missing-ref' }
+    $ref = $Matches[1]
+    if ($ref -match '^[0-9a-fA-F]{40}$') { return 'immutable-sha' }
+    return 'mutable-ref'
+}
+
+function Get-WorkflowRelationships {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$WorkflowPath,
+        [Parameter(Mandatory = $true)][string]$Text
+    )
+
+    $results = @()
+    $lineNumber = 0
+    foreach ($line in ($Text -split "`r?`n")) {
+        $lineNumber++
+        if ($line -notmatch '^\s*uses\s*:\s*(.+?)\s*$') { continue }
+
+        $raw = $Matches[1].Trim()
+        if (($raw.StartsWith("'") -and $raw.EndsWith("'")) -or ($raw.StartsWith('"') -and $raw.EndsWith('"'))) {
+            $raw = $raw.Substring(1, $raw.Length - 2)
+        }
+
+        $status = Get-PinStatus -Reference $raw
+        $results += [pscustomobject]@{
+            repository   = $Repository
+            workflowPath = $WorkflowPath
+            line         = $lineNumber
+            reference    = $raw
+            capability   = Get-Capability -Reference $raw
+            pinStatus    = $status
+            observation  = if ($status -eq 'dynamic-or-ambiguous') { 'ambiguous-not-asserted' } else { 'observed' }
+        }
+    }
+    return @($results)
+}
+
+function Get-PublicRepositoriesForOwner {
+    param([Parameter(Mandatory = $true)][string]$Owner)
+
+    $repoJson = & gh api "users/$Owner/repos?per_page=100&type=public&sort=full_name" 2>$null
+    if ($LASTEXITCODE -ne 0) { throw "Unable to enumerate public repositories for owner '$Owner'." }
+    $repos = @($repoJson | ConvertFrom-Json)
+    return @($repos | Where-Object { -not $_.archived } | ForEach-Object { $_.full_name })
+}
+
+function Get-RemoteWorkflowFiles {
+    param([Parameter(Mandatory = $true)][string]$Repository)
+
+    $listing = & gh api "repos/$Repository/contents/.github/workflows" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        $global:LASTEXITCODE = 0
+        return @()
+    }
+    $items = @($listing | ConvertFrom-Json)
+    return @($items | Where-Object { $_.type -eq 'file' -and $_.name -match '\.ya?ml$' })
+}
+
+function Get-RemoteText {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $json = & gh api "repos/$Repository/contents/$Path" 2>$null
+    if ($LASTEXITCODE -ne 0) { throw "Unable to read $Repository/$Path" }
+    $payload = $json | ConvertFrom-Json
+    if ($payload.encoding -ne 'base64') { throw "Unsupported encoding '$($payload.encoding)' for $Repository/$Path" }
+    $bytes = [Convert]::FromBase64String(($payload.content -replace '\s', ''))
+    return [Text.Encoding]::UTF8.GetString($bytes)
+}
+
+$relationships = @()
+$repositoriesScanned = @()
+$workflowCount = 0
+
+if ($FixtureRoot) {
+    $resolved = (Resolve-Path -LiteralPath $FixtureRoot).Path
+    $files = @(Get-ChildItem -LiteralPath $resolved -File -Recurse | Where-Object { $_.Name -match '\.ya?ml$' } | Sort-Object FullName)
+    $repositoriesScanned += 'fixture/local'
+    foreach ($file in $files) {
+        $workflowCount++
+        $relative = $file.FullName.Substring($resolved.Length).TrimStart([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar).Replace('\', '/')
+        $text = [IO.File]::ReadAllText($file.FullName)
+        $relationships += @(Get-WorkflowRelationships -Repository 'fixture/local' -WorkflowPath $relative -Text $text)
+    }
+}
+else {
+    if (-not $env:GH_TOKEN) { throw 'GH_TOKEN is required for public repository discovery.' }
+    foreach ($owner in ($Owners | Sort-Object -Unique)) {
+        foreach ($repository in (Get-PublicRepositoriesForOwner -Owner $owner)) {
+            $repositoriesScanned += $repository
+            foreach ($workflow in (Get-RemoteWorkflowFiles -Repository $repository)) {
+                $workflowCount++
+                $text = Get-RemoteText -Repository $repository -Path $workflow.path
+                $relationships += @(Get-WorkflowRelationships -Repository $repository -WorkflowPath $workflow.path -Text $text)
+            }
+        }
+    }
+}
+
+$relationships = @($relationships | Sort-Object repository, workflowPath, line, reference)
+$repositoriesScanned = @($repositoriesScanned | Sort-Object -Unique)
+
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+$jsonPath = Join-Path $OutputDirectory 'public-validation-consumers.json'
+$markdownPath = Join-Path $OutputDirectory 'public-validation-consumers.md'
+
+$document = [ordered]@{
+    schemaVersion = '1.0'
+    authority = 'derived-non-authoritative'
+    semantics = [ordered]@{
+        sourceOfTruth = 'consumer repository workflows'
+        inventory = 'observation only; regenerate instead of hand editing'
+        ambiguous = 'dynamic or ambiguous uses references are reported but not asserted as relationships'
+    }
+    generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+    repositoriesScanned = $repositoriesScanned
+    workflowCount = $workflowCount
+    relationships = $relationships
+}
+$document | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $jsonPath -Encoding utf8
+
+$lines = @(
+    '# Derived public validation consumer inventory',
+    '',
+    '> This report is generated observation, not configuration. Consumer workflows are authoritative.',
+    '',
+    "Repositories scanned: $($repositoriesScanned.Count)",
+    "Workflow files scanned: $workflowCount",
+    "Relationships observed: $($relationships.Count)",
+    '',
+    '| Repository | Workflow | Capability | Reference | Pin | Observation |',
+    '| --- | --- | --- | --- | --- | --- |'
+)
+foreach ($item in $relationships) {
+    $lines += "| $($item.repository) | `$($item.workflowPath)` | $($item.capability) | `$($item.reference)` | $($item.pinStatus) | $($item.observation) |"
+}
+$lines -join "`n" | Set-Content -LiteralPath $markdownPath -Encoding utf8
+
+Write-Host "Wrote $jsonPath"
+Write-Host "Wrote $markdownPath"

--- a/scripts/github/Get-PublicValidationConsumers.ps1
+++ b/scripts/github/Get-PublicValidationConsumers.ps1
@@ -162,7 +162,7 @@ $lines = @(
     '| --- | --- | --- | --- | --- | --- |'
 )
 foreach ($item in $relationships) {
-    $lines += "| $($item.repository) | `$($item.workflowPath)` | $($item.capability) | `$($item.reference)` | $($item.pinStatus) | $($item.observation) |"
+    $lines += "| $($item.repository) | $($item.workflowPath) | $($item.capability) | $($item.reference) | $($item.pinStatus) | $($item.observation) |"
 }
 $lines -join "`n" | Set-Content -LiteralPath $markdownPath -Encoding utf8
 

--- a/scripts/github/Get-PublicValidationConsumers.ps1
+++ b/scripts/github/Get-PublicValidationConsumers.ps1
@@ -42,7 +42,7 @@ function Get-WorkflowRelationships {
     $lineNumber = 0
     foreach ($line in ($Text -split "`r?`n")) {
         $lineNumber++
-        if ($line -notmatch '^\s*uses\s*:\s*(.+?)\s*$') { continue }
+        if ($line -notmatch '^\s*(?:-\s*)?uses\s*:\s*(.+?)\s*$') { continue }
 
         $raw = $Matches[1].Trim()
         if (($raw.StartsWith("'") -and $raw.EndsWith("'")) -or ($raw.StartsWith('"') -and $raw.EndsWith('"'))) {

--- a/tests/fixtures/consumer-inventory/sample.yml
+++ b/tests/fixtures/consumer-inventory/sample.yml
@@ -1,0 +1,18 @@
+name: Fixture
+on: [push]
+permissions:
+  contents: read
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc
+      - uses: actions/dependency-review-action@v5
+  powershell:
+    uses: SupraShellScripts/github-ops-lab/.github/workflows/powershell-compatibility.yml@main
+  ambiguous:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${{ inputs.dynamic_action }}


### PR DESCRIPTION
## Purpose
Implement #17 without creating a second source of truth.

## Model
- consumer workflows remain authoritative;
- the lab scans public workflow files and derives an observation;
- JSON and Markdown outputs are generated evidence, not configuration;
- ambiguous/dynamic `uses:` references are reported but not asserted;
- no central hand-maintained consumer registry is introduced.

## Implementation
- `scripts/github/Get-PublicValidationConsumers.ps1` discovers active public repositories for the bounded owner set and scans `.github/workflows/*.yml|*.yaml`;
- classifies known lab/security capabilities plus all other action/reusable-workflow references;
- records immutable-SHA vs mutable-ref posture;
- `public-consumer-inventory.yml` self-tests against fixtures on PRs and generates/uploads portfolio evidence on main/schedule/manual runs;
- `docs/consumer-inventory.md` documents authority and exception semantics.

## Post-merge correction
The first real portfolio artifact exposed two scanner semantics that need correction before its pin findings are treated as actionable: inline YAML comments following an immutable SHA and same-repository `./...` references. A follow-up correction is being made without changing the source-of-truth model.