### PR TITLE
Correct derived inventory pin semantics

### DIFF
--- a/.github/workflows/public-consumer-inventory.yml
+++ b/.github/workflows/public-consumer-inventory.yml
@@ -40,13 +40,17 @@ jobs:
         run: |
           $doc = Get-Content ./out-fixture/public-validation-consumers.json -Raw | ConvertFrom-Json
           if ($doc.authority -ne 'derived-non-authoritative') { throw 'Authority marker missing.' }
-          if (@($doc.relationships).Count -ne 6) { throw "Expected 6 relationships, got $(@($doc.relationships).Count)." }
+          if ($doc.schemaVersion -ne '1.1') { throw 'Expected schema version 1.1.' }
+          if (@($doc.relationships).Count -ne 8) { throw "Expected 8 relationships, got $(@($doc.relationships).Count)." }
           if (@($doc.relationships | Where-Object capability -eq 'github-actions-security').Count -ne 1) { throw 'zizmor capability not detected.' }
           if (@($doc.relationships | Where-Object capability -eq 'repository-security-posture').Count -ne 1) { throw 'Scorecard capability not detected.' }
           if (@($doc.relationships | Where-Object capability -eq 'dependency-review').Count -ne 1) { throw 'Dependency review capability not detected.' }
           if (@($doc.relationships | Where-Object capability -eq 'powershell-compatibility').Count -ne 1) { throw 'PowerShell compatibility capability not detected.' }
-          if (@($doc.relationships | Where-Object pinStatus -eq 'immutable-sha').Count -ne 3) { throw 'Immutable SHA classification mismatch.' }
+          if (@($doc.relationships | Where-Object pinStatus -eq 'immutable-sha').Count -ne 4) { throw 'Immutable SHA classification mismatch.' }
           if (@($doc.relationships | Where-Object pinStatus -eq 'mutable-ref').Count -ne 2) { throw 'Mutable ref classification mismatch.' }
+          if (@($doc.relationships | Where-Object pinStatus -eq 'same-repository-reference').Count -ne 1) { throw 'Same-repository classification mismatch.' }
+          $commented = @($doc.relationships | Where-Object reference -eq 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8')
+          if ($commented.Count -ne 2) { throw 'Inline YAML comment was not normalized away.' }
           $ambiguous = @($doc.relationships | Where-Object observation -eq 'ambiguous-not-asserted')
           if ($ambiguous.Count -ne 1) { throw 'Ambiguous uses reference was not conservatively classified.' }
 

--- a/scripts/github/Get-PublicValidationConsumers.ps1
+++ b/scripts/github/Get-PublicValidationConsumers.ps1
@@ -21,10 +21,26 @@ function Get-Capability {
     return 'other-action-or-workflow'
 }
 
+function Normalize-UsesReference {
+    param([Parameter(Mandatory = $true)][string]$Raw)
+
+    $value = $Raw.Trim()
+    if (($value.StartsWith("'") -and $value.EndsWith("'")) -or ($value.StartsWith('"') -and $value.EndsWith('"'))) {
+        return $value.Substring(1, $value.Length - 2)
+    }
+
+    # For an unquoted YAML scalar, whitespace followed by # begins an inline comment.
+    # Strip the comment before interpreting the action/workflow ref so a documented
+    # immutable SHA remains an immutable SHA.
+    $value = $value -replace '\s+#.*$', ''
+    return $value.Trim()
+}
+
 function Get-PinStatus {
     param([Parameter(Mandatory = $true)][string]$Reference)
 
     if ($Reference -match '\$\{\{') { return 'dynamic-or-ambiguous' }
+    if ($Reference.StartsWith('./')) { return 'same-repository-reference' }
     if ($Reference -notmatch '@([^\s#]+)$') { return 'missing-ref' }
     $ref = $Matches[1]
     if ($ref -match '^[0-9a-fA-F]{40}$') { return 'immutable-sha' }
@@ -44,11 +60,7 @@ function Get-WorkflowRelationships {
         $lineNumber++
         if ($line -notmatch '^\s*(?:-\s*)?uses\s*:\s*(.+?)\s*$') { continue }
 
-        $raw = $Matches[1].Trim()
-        if (($raw.StartsWith("'") -and $raw.EndsWith("'")) -or ($raw.StartsWith('"') -and $raw.EndsWith('"'))) {
-            $raw = $raw.Substring(1, $raw.Length - 2)
-        }
-
+        $raw = Normalize-UsesReference -Raw $Matches[1]
         $status = Get-PinStatus -Reference $raw
         $results += [pscustomobject]@{
             repository   = $Repository
@@ -135,12 +147,13 @@ $jsonPath = Join-Path $OutputDirectory 'public-validation-consumers.json'
 $markdownPath = Join-Path $OutputDirectory 'public-validation-consumers.md'
 
 $document = [ordered]@{
-    schemaVersion = '1.0'
+    schemaVersion = '1.1'
     authority = 'derived-non-authoritative'
     semantics = [ordered]@{
         sourceOfTruth = 'consumer repository workflows'
         inventory = 'observation only; regenerate instead of hand editing'
         ambiguous = 'dynamic or ambiguous uses references are reported but not asserted as relationships'
+        sameRepository = 'relative ./ uses references execute from the same repository revision and do not require an external action ref'
     }
     generatedAtUtc = [DateTime]::UtcNow.ToString('o')
     repositoriesScanned = $repositoriesScanned

--- a/tests/fixtures/consumer-inventory/sample.yml
+++ b/tests/fixtures/consumer-inventory/sample.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/local-check
       - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054
       - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc
       - uses: actions/dependency-review-action@v5


### PR DESCRIPTION
## Purpose
Correct evidence defects exposed by the first real portfolio inventory before using its pin findings for remediation.

## Fixes
- strip ordinary inline YAML comments from unquoted `uses:` scalars before interpreting refs;
- classify `./...` references as `same-repository-reference` rather than `missing-ref`;
- bump inventory schema to 1.1 and document same-repository semantics;
- extend fixtures to prove both cases.

## Why
The first generated portfolio artifact incorrectly marked documented immutable SHAs and local actions/workflows as missing refs. Those are scanner defects, not consumer defects.

Re-closes #17 when the corrected portfolio observation succeeds.