### PR TITLE
Add generic GitHub Pages Actions configurator

### DIFF
--- a/.github/workflows/public-safe-validation.yml
+++ b/.github/workflows/public-safe-validation.yml
@@ -75,3 +75,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/github/Repair-UpstreamForks.ps1 -AuditOnly
+
+  pages-helper-audit:
+    name: Pages helper read-only audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Exercise Pages helper without mutations
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/github/Set-GitHubPagesWorkflow.ps1 SupraShellScripts/github-ops-lab -AuditOnly

--- a/README.md
+++ b/README.md
@@ -29,3 +29,30 @@ Not allowed here:
 Pull-request and push validation is non-mutating and uses minimal `GITHUB_TOKEN` permissions. Any future workflow capable of modifying another public repository must be separately designed, manually dispatched, narrowly scoped, and reviewed before it is enabled.
 
 Stable reusable tooling should graduate to its durable public home rather than turning this lab into a product repository.
+
+## GitHub Pages source configuration
+
+`scripts/github/Set-GitHubPagesWorkflow.ps1` idempotently configures one explicitly named **public** repository so **Settings > Pages > Source** uses **GitHub Actions**. It does not create or alter the target repository's Pages deployment workflow.
+
+Read-only audit:
+
+```powershell
+./scripts/github/Set-GitHubPagesWorkflow.ps1 SupraCraft/VanillaCord -AuditOnly
+```
+
+Preview:
+
+```powershell
+./scripts/github/Set-GitHubPagesWorkflow.ps1 SupraCraft/VanillaCord -WhatIf
+```
+
+Apply:
+
+```powershell
+$env:GH_MUTATION_TOKEN = '<narrowly scoped token>'
+./scripts/github/Set-GitHubPagesWorkflow.ps1 SupraCraft/VanillaCord
+```
+
+The mutation token must be authorized for the target repository with GitHub Pages and repository Administration write permissions. Keep it repository-scoped rather than organization-wide. Reads may continue to use the ordinary `gh` authentication or `GH_TOKEN`; the helper temporarily uses `GH_MUTATION_TOKEN` only for the mutation and then restores the read token.
+
+The helper refuses private and archived repositories, supports `-WhatIf`, treats an already-correct `build_type=workflow` configuration as a no-op, and re-reads the Pages settings after mutation to fail closed if the requested state was not applied.

--- a/scripts/github/Set-GitHubPagesWorkflow.ps1
+++ b/scripts/github/Set-GitHubPagesWorkflow.ps1
@@ -1,0 +1,189 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+  Configure a public GitHub repository to publish GitHub Pages with GitHub Actions.
+
+.DESCRIPTION
+  Idempotently configures the repository's GitHub Pages build type to `workflow`,
+  which is the REST API equivalent of selecting Settings > Pages > Source >
+  GitHub Actions.
+
+  The script is intentionally bounded:
+    * public repositories only;
+    * one explicitly named repository per invocation;
+    * read-only unless mutation is requested;
+    * mutations require GH_MUTATION_TOKEN;
+    * -AuditOnly and -WhatIf never change repository settings;
+    * post-mutation verification fails closed if GitHub does not report
+      build_type=workflow.
+
+  This script does not create a Pages deployment workflow. The target repository
+  remains responsible for its own .github/workflows Pages deployment definition.
+#>
+
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+    [string]$Repository,
+
+    [switch]$AuditOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-GhJson {
+    param(
+        [Parameter(Mandatory)][string[]]$Args
+    )
+
+    $raw = & gh @Args 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh $($Args -join ' ') failed:`n$raw"
+    }
+    if (-not $raw) {
+        return $null
+    }
+    return ($raw | Out-String | ConvertFrom-Json)
+}
+
+function Get-GitHubPagesSite {
+    param(
+        [Parameter(Mandatory)][string]$Repo
+    )
+
+    $raw = & gh api "repos/$Repo/pages" 2>&1
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
+        if (-not $raw) {
+            throw "GitHub returned an empty Pages response for $Repo."
+        }
+        return ($raw | Out-String | ConvertFrom-Json)
+    }
+
+    $message = ($raw | Out-String)
+    if ($message -match '(?i)HTTP\s+404|Not Found') {
+        return $null
+    }
+
+    throw "Unable to read GitHub Pages settings for $Repo:`n$message"
+}
+
+function Invoke-GhMutation {
+    param(
+        [Parameter(Mandatory)][string[]]$Args
+    )
+
+    if (-not $env:GH_MUTATION_TOKEN) {
+        throw 'Mutation requested but GH_MUTATION_TOKEN is not set.'
+    }
+
+    $readToken = $env:GH_TOKEN
+    try {
+        $env:GH_TOKEN = $env:GH_MUTATION_TOKEN
+        & gh @Args
+        if ($LASTEXITCODE -ne 0) {
+            throw "gh $($Args -join ' ') mutation failed."
+        }
+    }
+    finally {
+        $env:GH_TOKEN = $readToken
+    }
+}
+
+& gh auth status
+if ($LASTEXITCODE -ne 0) {
+    throw 'GitHub CLI is not authenticated. Run: gh auth login'
+}
+
+$repo = Invoke-GhJson -Args @('api', "repos/$Repository")
+if ([string]$repo.visibility -ne 'public') {
+    throw "$Repository is not public; this public-safe helper refuses to operate on it."
+}
+if ([bool]$repo.archived) {
+    throw "$Repository is archived; refusing to change Pages settings."
+}
+
+$pages = Get-GitHubPagesSite -Repo $Repository
+$currentBuildType = if ($null -eq $pages) { 'not-configured' } else { [string]$pages.build_type }
+
+Write-Host "Repository:       $Repository"
+Write-Host "Visibility:       $($repo.visibility)"
+Write-Host "Pages build type: $currentBuildType"
+
+if ($currentBuildType -eq 'workflow') {
+    Write-Host 'GitHub Pages already uses GitHub Actions; no change is required.' -ForegroundColor Green
+    [pscustomobject]@{
+        Repository = $Repository
+        Before = 'workflow'
+        After = 'workflow'
+        Changed = $false
+        Mode = if ($AuditOnly) { 'audit' } else { 'apply' }
+    }
+    return
+}
+
+if ($AuditOnly) {
+    Write-Host 'Audit only: GitHub Pages is not configured for GitHub Actions.' -ForegroundColor Yellow
+    [pscustomobject]@{
+        Repository = $Repository
+        Before = $currentBuildType
+        After = $currentBuildType
+        Changed = $false
+        Mode = 'audit'
+    }
+    return
+}
+
+$action = if ($null -eq $pages) {
+    'Create GitHub Pages site with GitHub Actions as the build source'
+} else {
+    "Change GitHub Pages build type from '$currentBuildType' to 'workflow'"
+}
+
+if ($PSCmdlet.ShouldProcess($Repository, $action)) {
+    if ($null -eq $pages) {
+        Invoke-GhMutation -Args @(
+            'api', '--method', 'POST', "repos/$Repository/pages",
+            '-f', 'build_type=workflow', '--silent'
+        )
+    }
+    else {
+        Invoke-GhMutation -Args @(
+            'api', '--method', 'PUT', "repos/$Repository/pages",
+            '-f', 'build_type=workflow', '--silent'
+        )
+    }
+
+    $verified = Get-GitHubPagesSite -Repo $Repository
+    if ($null -eq $verified -or [string]$verified.build_type -ne 'workflow') {
+        $observed = if ($null -eq $verified) { 'not-configured' } else { [string]$verified.build_type }
+        throw "Pages mutation did not verify. Expected build_type=workflow, observed '$observed'."
+    }
+
+    Write-Host 'GitHub Pages now uses GitHub Actions.' -ForegroundColor Green
+    [pscustomobject]@{
+        Repository = $Repository
+        Before = $currentBuildType
+        After = 'workflow'
+        Changed = $true
+        Mode = 'apply'
+    }
+}
+
+<#
+Examples:
+
+  # Read-only inspection
+  ./scripts/github/Set-GitHubPagesWorkflow.ps1 SupraCraft/VanillaCord -AuditOnly
+
+  # Preview the mutation
+  ./scripts/github/Set-GitHubPagesWorkflow.ps1 SupraCraft/VanillaCord -WhatIf
+
+  # Apply. Keep a read token in GH_TOKEN if desired; mutations use the separately
+  # supplied narrowly scoped GH_MUTATION_TOKEN.
+  $env:GH_MUTATION_TOKEN = '<token with Pages + Administration write for the target repo>'
+  ./scripts/github/Set-GitHubPagesWorkflow.ps1 SupraCraft/VanillaCord
+#>

--- a/scripts/github/Set-GitHubPagesWorkflow.ps1
+++ b/scripts/github/Set-GitHubPagesWorkflow.ps1
@@ -65,6 +65,9 @@ function Get-GitHubPagesSite {
 
     $message = ($raw | Out-String)
     if ($message -match '(?i)HTTP\s+404|Not Found') {
+        # A repository without a configured Pages site is a normal probe result.
+        # Do not allow gh's expected 404 to leak into the script process exit code.
+        $global:LASTEXITCODE = 0
         return $null
     }
 

--- a/scripts/github/Set-GitHubPagesWorkflow.ps1
+++ b/scripts/github/Set-GitHubPagesWorkflow.ps1
@@ -68,7 +68,7 @@ function Get-GitHubPagesSite {
         return $null
     }
 
-    throw "Unable to read GitHub Pages settings for $Repo:`n$message"
+    throw "Unable to read GitHub Pages settings for ${Repo}:`n$message"
 }
 
 function Invoke-GhMutation {


### PR DESCRIPTION
## Objective
Add a durable, idempotent helper for configuring a public repository's GitHub Pages source to GitHub Actions without requiring manual Settings clicks.

## Changes
- add `scripts/github/Set-GitHubPagesWorkflow.ps1`;
- support audit-only and `-WhatIf` modes;
- require a separate `GH_MUTATION_TOKEN` for mutations;
- refuse private and archived repositories;
- create Pages with `build_type=workflow` when absent or update legacy Pages to `workflow` when present;
- re-read the setting after mutation and fail closed if verification does not match;
- document usage and required token scope;
- exercise the helper read-only in public CI.

## Safety boundary
The helper targets exactly one explicitly named public repository per invocation. CI remains read-only. No organization-wide mutation workflow or credential is added.

## Acceptance
- [ ] PowerShell parses on Linux, Windows, and macOS.
- [ ] Read-only Pages audit succeeds in CI.
- [ ] Existing public-security checks remain green.
- [ ] No mutation occurs in CI.
