### PR TITLE
Extract reusable public-site release-readiness workflow

### DIFF
--- a/.github/workflows/public-site-readiness-selftest.yml
+++ b/.github/workflows/public-site-readiness-selftest.yml
@@ -1,0 +1,50 @@
+name: Public site readiness self-test
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/public-site-readiness.yml'
+      - '.github/workflows/public-site-readiness-selftest.yml'
+      - 'tests/fixtures/public-site-readiness/**'
+      - 'docs/public-site-release-readiness.md'
+      - 'README.md'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/public-site-readiness.yml'
+      - '.github/workflows/public-site-readiness-selftest.yml'
+      - 'tests/fixtures/public-site-readiness/**'
+      - 'docs/public-site-release-readiness.md'
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-site-readiness-selftest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  selftest:
+    uses: ./.github/workflows/public-site-readiness.yml
+    with:
+      working_directory: tests/fixtures/public-site-readiness
+      build_command: npm run site:build
+      validate_command: npm run site:validate
+      lychee_args: >-
+        --verbose
+        --no-progress
+        --max-retries 2
+        --timeout 20
+        --accept 200,204,206,429
+        --exclude '^http://127\.0\.0\.1(:[0-9]+)?/'
+        './tests/fixtures/public-site-readiness/build/public-site/**/*.html'
+      evidence_paths: |
+        tests/fixtures/public-site-readiness/build/playwright-report
+        tests/fixtures/public-site-readiness/build/playwright-results
+        tests/fixtures/public-site-readiness/build/lighthouse
+        lychee/out.md
+      artifact_name: public-site-readiness-selftest
+      retention_days: 14

--- a/.github/workflows/public-site-readiness.yml
+++ b/.github/workflows/public-site-readiness.yml
@@ -1,0 +1,165 @@
+name: Public site release readiness
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        description: Relative directory containing the consumer web QA package and configs
+        required: false
+        type: string
+        default: .
+      node_version:
+        description: Node.js version used by the consumer QA package
+        required: false
+        type: string
+        default: '22'
+      build_command:
+        description: Command that builds exact candidate site bytes for local qualification
+        required: true
+        type: string
+      validate_command:
+        description: Optional deterministic candidate validation command
+        required: false
+        type: string
+        default: ''
+      install_command:
+        description: Command that installs the consumer web QA dependencies
+        required: false
+        type: string
+        default: npm install --ignore-scripts --no-audit --no-fund
+      browser_install_command:
+        description: Command that installs the required Playwright browser engines
+        required: false
+        type: string
+        default: npx playwright install --with-deps chromium firefox webkit
+      playwright_command:
+        description: Consumer-owned Playwright/axe browser and journey command
+        required: false
+        type: string
+        default: npm run site:test
+      lighthouse_enabled:
+        description: Run the consumer-owned Lighthouse CI command
+        required: false
+        type: boolean
+        default: true
+      lighthouse_command:
+        description: Consumer-owned Lighthouse CI command
+        required: false
+        type: string
+        default: npm run site:lighthouse
+      lychee_args:
+        description: Complete public-safe Lychee arguments and paths, evaluated from repository root
+        required: true
+        type: string
+      evidence_paths:
+        description: Newline-separated repository-relative evidence paths to upload
+        required: false
+        type: string
+        default: |
+          build/playwright-report
+          build/playwright-results
+          build/lighthouse
+          lychee/out.md
+      artifact_name:
+        description: Evidence artifact name
+        required: false
+        type: string
+        default: public-site-readiness
+      retention_days:
+        description: Evidence retention in days
+        required: false
+        type: number
+        default: 14
+
+permissions:
+  contents: read
+
+jobs:
+  candidate:
+    name: Candidate public site
+    runs-on: ubuntu-latest
+    env:
+      WORKING_DIRECTORY: ${{ inputs.working_directory }}
+    steps:
+      - name: Checkout caller revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Build candidate public site
+        env:
+          COMMAND: ${{ inputs.build_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKING_DIRECTORY"
+          bash -euo pipefail -c "$COMMAND"
+
+      - name: Validate deterministic candidate contract
+        if: ${{ inputs.validate_command != '' }}
+        env:
+          COMMAND: ${{ inputs.validate_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKING_DIRECTORY"
+          bash -euo pipefail -c "$COMMAND"
+
+      - name: Install web QA dependencies
+        env:
+          COMMAND: ${{ inputs.install_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKING_DIRECTORY"
+          bash -euo pipefail -c "$COMMAND"
+
+      - name: Install Playwright browser engines
+        env:
+          COMMAND: ${{ inputs.browser_install_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKING_DIRECTORY"
+          bash -euo pipefail -c "$COMMAND"
+
+      - name: Run Playwright browser and accessibility matrix
+        env:
+          COMMAND: ${{ inputs.playwright_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKING_DIRECTORY"
+          bash -euo pipefail -c "$COMMAND"
+
+      - name: Resolve Chromium for Lighthouse
+        if: ${{ inputs.lighthouse_enabled }}
+        run: |
+          set -euo pipefail
+          cd "$WORKING_DIRECTORY"
+          CHROME_PATH="$(node --input-type=module -e "import { chromium } from '@playwright/test'; process.stdout.write(chromium.executablePath())")"
+          echo "CHROME_PATH=$CHROME_PATH" >> "$GITHUB_ENV"
+
+      - name: Run Lighthouse CI budgets
+        if: ${{ inputs.lighthouse_enabled }}
+        env:
+          COMMAND: ${{ inputs.lighthouse_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKING_DIRECTORY"
+          bash -euo pipefail -c "$COMMAND"
+
+      - name: Check public link integrity
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
+        with:
+          lycheeVersion: v0.24.2
+          args: ${{ inputs.lychee_args }}
+
+      - name: Upload public-site readiness evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.evidence_paths }}
+          if-no-files-found: ignore
+          retention-days: ${{ inputs.retention_days }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Pull-request and push validation is non-mutating and uses minimal `GITHUB_TOKEN`
 
 Stable reusable tooling should graduate to its durable public home rather than turning this lab into a product repository.
 
+## Reusable public-site release readiness
+
+`.github/workflows/public-site-readiness.yml` extracts the common public-web CI mechanics proven by the SupraCraft VanillaCord and Bridge pilots. Consumers keep their own candidate generator, deterministic checks, Playwright routes/journeys, theme assertions, Lighthouse routes/budgets, and Lychee paths; the reusable workflow supplies the shared pinned execution mechanics and evidence upload.
+
+A synthetic consumer in `tests/fixtures/public-site-readiness/` exercises the reusable workflow through `.github/workflows/public-site-readiness-selftest.yml`.
+
+See [`docs/public-site-release-readiness.md`](docs/public-site-release-readiness.md) for the consumer contract, base-path containment requirement, accessibility boundary, and pinned-use example.
+
 ## GitHub Pages source configuration
 
 `scripts/github/Set-GitHubPagesWorkflow.ps1` idempotently configures one explicitly named **public** repository so **Settings > Pages > Source** uses **GitHub Actions**. It does not create or alter the target repository's Pages deployment workflow.

--- a/docs/public-site-release-readiness.md
+++ b/docs/public-site-release-readiness.md
@@ -1,0 +1,126 @@
+# Reusable public-site release readiness
+
+This repository provides a **public-safe reusable GitHub Actions workflow** for the common mechanics proven by the SupraCraft VanillaCord and Bridge public-web pilots.
+
+The reusable workflow deliberately does **not** own project-specific routes, release semantics, Maven coordinates, download/support behavior, branding, or accessibility claims. Consumers keep those assertions locally.
+
+## Reusable workflow
+
+Path:
+
+```text
+.github/workflows/public-site-readiness.yml
+```
+
+A consumer calls it from a thin local workflow:
+
+```yaml
+name: public-site-readiness
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/build-public-site.py'
+      - 'scripts/check-public-site.py'
+      - 'package.json'
+      - 'playwright.config.mjs'
+      - 'lighthouserc.cjs'
+      - 'tests/site/**'
+      - '.github/workflows/public-site-readiness.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/build-public-site.py'
+      - 'scripts/check-public-site.py'
+      - 'package.json'
+      - 'playwright.config.mjs'
+      - 'lighthouserc.cjs'
+      - 'tests/site/**'
+      - '.github/workflows/public-site-readiness.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  readiness:
+    uses: SupraShellScripts/github-ops-lab/.github/workflows/public-site-readiness.yml@<pinned-ref>
+    with:
+      build_command: >-
+        python3 ./scripts/build-public-site.py
+        --output build/public-site
+        --base-url http://127.0.0.1:4173/
+      validate_command: >-
+        python3 ./scripts/check-public-site.py
+        --site-dir build/public-site
+        --navigation-base http://127.0.0.1:4173/
+      lychee_args: >-
+        --verbose
+        --no-progress
+        --max-retries 2
+        --timeout 20
+        --accept 200,204,206,429
+        --exclude '^http://127\\.0\\.0\\.1(:[0-9]+)?/'
+        './README.md'
+        './docs/**/*.md'
+        './build/public-site/**/*.html'
+```
+
+Pin the reusable workflow to a reviewed immutable commit SHA or a deliberately managed release tag. Do not consume a floating development branch in release-critical repositories.
+
+## Consumer-owned contract
+
+Each consumer remains responsible for:
+
+- triggering the workflow on the correct branches and path filters;
+- generating the exact candidate bytes that would be published;
+- a deterministic candidate validator when the project has machine contracts;
+- `package.json` with pinned web-QA dependencies;
+- `playwright.config.*` with the intended browser/device matrix;
+- local Playwright specs for required routes and critical user journeys;
+- axe assertions and accessibility semantics relevant to that application;
+- 320 CSS-pixel reflow/overflow checks where the profile requires them;
+- theme assertions when Light/Dark/System behavior is part of the UI contract;
+- `lighthouserc.*` routes and thresholds when Lighthouse is applicable;
+- Lychee exclusions and paths appropriate to the repository;
+- separate post-deployment smoke against the real production URL.
+
+The common pilot baseline used desktop Chromium, Firefox, and WebKit plus Android-Chromium and iPhone-WebKit projects. A consumer may use a lighter profile only when its governing policy explicitly permits one.
+
+## Shared mechanics
+
+The reusable workflow provides:
+
+1. SHA-pinned source checkout with persisted credentials disabled;
+2. Node setup;
+3. candidate build command;
+4. optional deterministic candidate validation;
+5. consumer dependency installation;
+6. Playwright Chromium/Firefox/WebKit engine installation;
+7. consumer Playwright/axe execution;
+8. Chromium resolution for Lighthouse;
+9. optional consumer Lighthouse execution;
+10. SHA-pinned Lychee link validation;
+11. uploaded Playwright/Lighthouse/Lychee evidence.
+
+The workflow runs with `contents: read` and requires no private-repository credentials or organization-brand governance access.
+
+## Important Pages lesson: base-path containment
+
+GitHub Pages project sites live below a project base path, for example:
+
+```text
+https://example-org.github.io/project/
+```
+
+A same-origin browser assertion is insufficient: navigation can accidentally escape `/project/` to the organization root while remaining on the same origin. Project-local browser tests and deployed smoke must therefore assert both the expected origin **and** the expected project base path.
+
+## Accessibility boundary
+
+Automated axe and Lighthouse results are evidence, not accessibility certification. Projects targeting WCAG 2.2 AA / Revised Section 508 alignment still require appropriate manual review for keyboard behavior, zoom/reflow, semantics/screen-reader behavior, forced colors/high contrast, and other material interaction changes.
+
+## Stable-tool boundary
+
+This lab is an extraction and validation home. If the reusable workflow becomes a broadly consumed product with an independent lifecycle, graduate it to an appropriate durable public repository rather than turning `github-ops-lab` into a general-purpose product monorepo.

--- a/tests/fixtures/public-site-readiness/lighthouserc.cjs
+++ b/tests/fixtures/public-site-readiness/lighthouserc.cjs
@@ -1,0 +1,31 @@
+const baseURL = 'http://127.0.0.1:4174';
+
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: 'python3 -u -m http.server 4174 --directory build/public-site --bind 127.0.0.1',
+      startServerReadyPattern: 'Serving HTTP on',
+      startServerReadyTimeout: 120000,
+      numberOfRuns: 1,
+      settings: {
+        chromeFlags: '--no-sandbox'
+      },
+      url: [
+        `${baseURL}/`,
+        `${baseURL}/accessibility/`
+      ]
+    },
+    assert: {
+      assertions: {
+        'categories:accessibility': ['error', { minScore: 1 }],
+        'categories:best-practices': ['error', { minScore: 0.95 }],
+        'categories:seo': ['error', { minScore: 0.9 }],
+        'categories:performance': ['error', { minScore: 0.9 }]
+      }
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: './build/lighthouse'
+    }
+  }
+};

--- a/tests/fixtures/public-site-readiness/package.json
+++ b/tests/fixtures/public-site-readiness/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "github-ops-lab-public-site-readiness-selftest",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "site:build": "node ./scripts/build.mjs",
+    "site:validate": "node ./scripts/validate.mjs",
+    "site:test": "playwright test",
+    "site:lighthouse": "lhci autorun"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.13.0",
+    "@lhci/cli": "0.15.1",
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/tests/fixtures/public-site-readiness/playwright.config.mjs
+++ b/tests/fixtures/public-site-readiness/playwright.config.mjs
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = 'http://127.0.0.1:4173/';
+
+export default defineConfig({
+  testDir: './tests/site',
+  outputDir: 'build/playwright-results',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [['line'], ['html', { outputFolder: 'build/playwright-report', open: 'never' }]]
+    : 'list',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  },
+  webServer: {
+    command: 'python3 -u -m http.server 4173 --directory build/public-site --bind 127.0.0.1',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  },
+  projects: [
+    { name: 'desktop-chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'desktop-firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'desktop-webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'android-chromium', use: { ...devices['Pixel 5'] } },
+    { name: 'iphone-webkit', use: { ...devices['iPhone 13'] } }
+  ]
+});

--- a/tests/fixtures/public-site-readiness/scripts/build.mjs
+++ b/tests/fixtures/public-site-readiness/scripts/build.mjs
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const out = path.resolve('build/public-site');
+fs.rmSync(out, { recursive: true, force: true });
+fs.mkdirSync(path.join(out, 'accessibility'), { recursive: true });
+
+const shell = ({ title, heading, body, current }) => `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#ffffff" data-effective-theme="light">
+  <title>${title}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+    body { margin: 0; line-height: 1.5; }
+    .skip { position: absolute; left: .5rem; top: -4rem; padding: .75rem; background: Canvas; color: CanvasText; }
+    .skip:focus { top: .5rem; }
+    header, main, footer { max-width: 60rem; margin: auto; padding: 1rem; }
+    nav { display: flex; flex-wrap: wrap; gap: .75rem; align-items: center; }
+    a, select { min-height: 2rem; }
+    main:focus { outline: 2px solid currentColor; outline-offset: 2px; }
+    pre { overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <a class="skip" href="#main-content">Skip to main content</a>
+  <header>
+    <nav aria-label="Primary">
+      <a href="${current === 'home' ? './' : '../'}"${current === 'home' ? ' aria-current="page"' : ''}>Home</a>
+      <a href="${current === 'home' ? './accessibility/' : './'}"${current === 'accessibility' ? ' aria-current="page"' : ''}>Accessibility</a>
+      <label>Theme
+        <select id="theme-select">
+          <option value="system">System</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+    </nav>
+  </header>
+  <main id="main-content" tabindex="-1">
+    <h1>${heading}</h1>
+    ${body}
+  </main>
+  <footer>Reusable workflow self-test fixture.</footer>
+  <script>
+    const select = document.querySelector('#theme-select');
+    const media = matchMedia('(prefers-color-scheme: dark)');
+    const meta = document.querySelector('meta[name="theme-color"]');
+    const apply = value => {
+      document.documentElement.removeAttribute('data-theme');
+      if (value === 'light' || value === 'dark') document.documentElement.dataset.theme = value;
+      const effective = value === 'system' ? (media.matches ? 'dark' : 'light') : value;
+      meta.dataset.effectiveTheme = effective;
+      meta.content = effective === 'dark' ? '#111111' : '#ffffff';
+    };
+    const stored = localStorage.getItem('selftest-theme') || 'system';
+    select.value = stored;
+    apply(stored);
+    select.addEventListener('change', () => { localStorage.setItem('selftest-theme', select.value); apply(select.value); });
+    media.addEventListener('change', () => { if (select.value === 'system') apply('system'); });
+  </script>
+</body>
+</html>`;
+
+fs.writeFileSync(path.join(out, 'index.html'), shell({
+  title: 'Public-site readiness self-test',
+  heading: 'Public-site readiness self-test',
+  current: 'home',
+  body: '<p>This synthetic candidate proves the reusable release-readiness workflow without project-specific product behavior.</p><p><a href="./accessibility/">Review accessibility notes</a></p>'
+}));
+
+fs.writeFileSync(path.join(out, 'accessibility', 'index.html'), shell({
+  title: 'Accessibility - public-site readiness self-test',
+  heading: 'Accessibility',
+  current: 'accessibility',
+  body: '<p>Automated checks are evidence, not certification. Manual accessibility review remains a consumer responsibility.</p>'
+}));

--- a/tests/fixtures/public-site-readiness/scripts/validate.mjs
+++ b/tests/fixtures/public-site-readiness/scripts/validate.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve('build/public-site');
+const required = [
+  'index.html',
+  path.join('accessibility', 'index.html')
+];
+
+for (const relative of required) {
+  const file = path.join(root, relative);
+  if (!fs.existsSync(file)) throw new Error(`missing candidate route: ${relative}`);
+  const html = fs.readFileSync(file, 'utf8');
+  for (const token of ['<html lang="en">', 'id="main-content"', 'aria-label="Primary"', 'id="theme-select"']) {
+    if (!html.includes(token)) throw new Error(`${relative} missing required token ${token}`);
+  }
+}
+
+console.log(`validated ${required.length} generated candidate routes`);

--- a/tests/fixtures/public-site-readiness/tests/site/readiness.spec.mjs
+++ b/tests/fixtures/public-site-readiness/tests/site/readiness.spec.mjs
@@ -73,7 +73,11 @@ test('320px reflow remains usable', async ({ page }) => {
   for (const route of routes) {
     await page.goto(route, { waitUntil: 'networkidle' });
     await assertNoHorizontalOverflow(page, `320px ${route}`);
-    for (const locator of [page.getByRole('link', { name: 'Home' }), page.getByRole('link', { name: 'Accessibility' }), page.locator('#theme-select')]) {
+    for (const locator of [
+      page.getByRole('link', { name: 'Home', exact: true }),
+      page.getByRole('link', { name: 'Accessibility', exact: true }),
+      page.locator('#theme-select')
+    ]) {
       await expect(locator).toBeVisible();
     }
   }

--- a/tests/fixtures/public-site-readiness/tests/site/readiness.spec.mjs
+++ b/tests/fixtures/public-site-readiness/tests/site/readiness.spec.mjs
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const routes = ['/', '/accessibility/'];
+
+async function assertNoHorizontalOverflow(page, label) {
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(overflow, `${label} must not overflow horizontally`).toBeLessThanOrEqual(1);
+}
+
+async function assertA11y(page, label) {
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'])
+    .analyze();
+  expect(results.violations, `${label} axe violations: ${results.violations.map(v => v.id).join(', ')}`).toEqual([]);
+}
+
+for (const route of routes) {
+  test(`${route} is a complete accessible candidate route`, async ({ page }, testInfo) => {
+    const consoleErrors = [];
+    const pageErrors = [];
+    page.on('console', message => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    page.on('pageerror', error => pageErrors.push(String(error)));
+
+    const response = await page.goto(route, { waitUntil: 'networkidle' });
+    expect(response?.status()).toBeLessThan(400);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('h1')).toHaveCount(1);
+    await expect(page.locator('nav[aria-label="Primary"]')).toHaveCount(1);
+    await expect(page.locator('main#main-content')).toHaveCount(1);
+    await expect(page.locator('[aria-current="page"]')).toHaveCount(1);
+    await expect(page.locator('#theme-select')).toHaveCount(1);
+    await expect(page.locator('a.skip[href="#main-content"]')).toHaveCount(1);
+    await assertNoHorizontalOverflow(page, `${testInfo.project.name} ${route}`);
+    await assertA11y(page, `${testInfo.project.name} ${route}`);
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+}
+
+test('consumer-owned primary journey works', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Review accessibility notes' }).click();
+  await expect(page).toHaveURL(/\/accessibility\/$/);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Accessibility');
+});
+
+test('consumer-owned theme contract persists explicit choices', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.removeItem('selftest-theme'));
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.reload();
+
+  const selector = page.locator('#theme-select');
+  await expect(selector).toHaveValue('system');
+  await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('data-effective-theme', 'light');
+
+  await selector.selectOption('dark');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await page.reload();
+  await expect(selector).toHaveValue('dark');
+
+  await selector.selectOption('system');
+  await expect(page.locator('html')).not.toHaveAttribute('data-theme', /.+/);
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await expect(page.locator('meta[name="theme-color"]')).toHaveAttribute('data-effective-theme', 'dark');
+});
+
+test('320px reflow remains usable', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 });
+  for (const route of routes) {
+    await page.goto(route, { waitUntil: 'networkidle' });
+    await assertNoHorizontalOverflow(page, `320px ${route}`);
+    for (const locator of [page.getByRole('link', { name: 'Home' }), page.getByRole('link', { name: 'Accessibility' }), page.locator('#theme-select')]) {
+      await expect(locator).toBeVisible();
+    }
+  }
+});
+
+test('desktop keyboard users can skip directly to main content', async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.startsWith('desktop-'), 'desktop keyboard check');
+  await page.goto('/');
+  await page.evaluate(() => document.activeElement?.blur());
+  await page.keyboard.press('Tab');
+  await expect(page.locator('.skip')).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('#main-content')).toBeFocused();
+});


### PR DESCRIPTION
## Summary

Implements the reusable workflow extraction authorized by #30 after both SupraCraft pilots passed candidate and deployed acceptance.

## Scope

- add a public-safe reusable `workflow_call` for common public-site readiness mechanics;
- retain consumer ownership of candidate generation, deterministic project contracts, Playwright routes/journeys, theme assertions, Lighthouse routes/budgets, and Lychee paths;
- keep permissions read-only and disable persisted checkout credentials;
- use the SHA-pinned action/tool pattern proven by the pilots;
- preserve Playwright/axe, Lighthouse, Lychee, and evidence upload as the shared mechanics;
- document the GitHub Pages project-base-path containment lesson;
- document that automated accessibility evidence is not certification;
- add a synthetic two-route consumer that exercises five browser/device projects, axe, theme persistence, 320px reflow, keyboard skip navigation, Lighthouse, link checking, deterministic validation, and evidence upload through the reusable workflow.

## Boundary

No SupraCraft-specific routes, Maven coordinates, download/support semantics, brand assets, private credentials, or private governance dependencies are encoded in the reusable layer.

## Validation

Do not merge until the exact PR head passes the new reusable-workflow self-test and the repository's existing public-safe validation workflows.

Closes no issue yet: #30 should remain open until at least one real downstream consumer is migrated to the pinned reusable workflow and the acceptance checklist is reconciled.