### PR TITLE
Add deterministic public-surface model/discovery conformance validator

### DIFF
--- a/.github/workflows/public-surface-conformance-selftest.yml
+++ b/.github/workflows/public-surface-conformance-selftest.yml
@@ -1,0 +1,31 @@
+name: Public surface conformance self-test
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/public-web/validate-surface-contract.py'
+      - 'tests/public-surface-conformance-selftest.py'
+      - 'docs/public-surface-conformance.md'
+      - '.github/workflows/public-surface-conformance-selftest.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/public-web/validate-surface-contract.py'
+      - 'tests/public-surface-conformance-selftest.py'
+      - 'docs/public-surface-conformance.md'
+      - '.github/workflows/public-surface-conformance-selftest.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Run positive and negative validator fixtures
+        run: python3 ./tests/public-surface-conformance-selftest.py

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ A synthetic consumer in `tests/fixtures/public-site-readiness/` exercises the re
 
 See [`docs/public-site-release-readiness.md`](docs/public-site-release-readiness.md) for the consumer contract, base-path containment requirement, accessibility boundary, and pinned-use example.
 
+## Public-surface model and discovery conformance
+
+`scripts/public-web/validate-surface-contract.py` provides the cheap deterministic validation layer for a consumer-owned public-surface model. It checks model reachability, rendered action classification, GitHub Pages base-path containment, canonical/title/indexability consistency, sitemap/`lastmod`, `robots.txt`, approved external handoffs, and machine-description discovery without executing JavaScript or replacing project-owned Playwright journeys.
+
+The validator is dependency-free, read-only, reproducible from exact inputs, repeatable by a fresh actor, reversible by virtue of making no mutation, and idempotent on unchanged inputs. Its positive/negative fixtures run in `.github/workflows/public-surface-conformance-selftest.yml`.
+
+See [`docs/public-surface-conformance.md`](docs/public-surface-conformance.md) for the normalized `public-surface-contract/1` shape, semantic HTML identifiers, evidence format, and consumer boundary. Bridge and VanillaCord adoption are tracked separately so project route/journey semantics remain local.
+
 ## GitHub Pages source configuration
 
 `scripts/github/Set-GitHubPagesWorkflow.ps1` idempotently configures one explicitly named **public** repository so **Settings > Pages > Source** uses **GitHub Actions**. It does not create or alter the target repository's Pages deployment workflow.

--- a/docs/public-surface-conformance.md
+++ b/docs/public-surface-conformance.md
@@ -112,6 +112,30 @@ https://example.org/project/guide/
 
 This avoids treating GitHub Pages project sites as origin-root sites.
 
+### Production identity versus candidate navigation identity
+
+`production_base_url` is the canonical/indexing identity. It is **not** assumed to be the URL used by the local candidate server.
+
+For example, Bridge can be generated with canonical URLs under:
+
+```text
+https://supracraft.github.io/Bridge/
+```
+
+while browser qualification serves the exact candidate at:
+
+```text
+http://127.0.0.1:4173/
+```
+
+Pass that ephemeral candidate identity with:
+
+```text
+--navigation-base http://127.0.0.1:4173/
+```
+
+The validator uses the production base for canonical/Sitemap/robots checks and the navigation base for rendered internal-link containment and route resolution. This separation prevents a correct candidate from being rejected merely because it is being tested before publication.
+
 ### Rendered state/action identifiers
 
 The rendered page declares its route/state identity:
@@ -140,6 +164,25 @@ A rendered action must resolve to exactly one class:
 - `exceptions` — narrow documented exceptions with a reason.
 
 A link/action that is rendered but unclassified fails validation.
+
+By default, each declared `navigation` action is required on every required route. A project can narrow that requirement:
+
+```json
+{
+  "action": "nav-releases",
+  "class": "global",
+  "to": "releases",
+  "required_on": ["home", "guide", "releases"]
+}
+```
+
+or mark the navigation declaration as classification-only:
+
+```json
+"required_on": false
+```
+
+Required non-terminal routes must also render at least one valid internal transition/navigation action, so a declared recovery concept cannot hide a real rendered dead end.
 
 ### Browser-required actions
 
@@ -223,7 +266,7 @@ or a prefix:
 
 When `handoff` is declared, rendered HTML must also expose the matching `data-surface-handoff` value.
 
-The validator rejects a declared internal action that exits the site and a declared external handoff that unexpectedly stays on the same origin.
+The validator rejects a declared internal action that exits the candidate site and a declared external handoff that unexpectedly stays on the candidate origin.
 
 ## Usage
 
@@ -231,6 +274,7 @@ The validator rejects a declared internal action that exits the site and a decla
 python3 scripts/public-web/validate-surface-contract.py \
   --contract ./PUBLIC_SURFACE.json \
   --site-dir ./build/public-site \
+  --navigation-base http://127.0.0.1:4173/ \
   --evidence ./build/public-surface-conformance.json
 ```
 
@@ -249,7 +293,7 @@ public-surface-conformance-evidence/1
 It records:
 
 - contract schema;
-- production base URL;
+- production canonical base URL and candidate navigation base URL;
 - route and expected-transition counts;
 - observed classified edges;
 - browser-required actions;

--- a/docs/public-surface-conformance.md
+++ b/docs/public-surface-conformance.md
@@ -11,6 +11,7 @@ The consumer repository owns:
 - route/state identities;
 - critical flow transitions;
 - global/utility navigation actions;
+- same-site machine/resource endpoints exposed as links;
 - approved external handoffs;
 - indexability decisions;
 - canonical production base URL;
@@ -76,6 +77,18 @@ Minimal example:
       "action": "nav-home",
       "class": "global",
       "to": "home"
+    },
+    {
+      "action": "skip-main",
+      "class": "utility",
+      "to": "$self"
+    }
+  ],
+  "resources": [
+    {
+      "action": "machine-project",
+      "path": "/surface.json",
+      "required_on": ["home"]
     }
   ],
   "handoffs": [
@@ -134,7 +147,7 @@ Pass that ephemeral candidate identity with:
 --navigation-base http://127.0.0.1:4173/
 ```
 
-The validator uses the production base for canonical/Sitemap/robots checks and the navigation base for rendered internal-link containment and route resolution. This separation prevents a correct candidate from being rejected merely because it is being tested before publication.
+The validator uses the production base for canonical/Sitemap/robots checks and the navigation base for rendered internal-link/resource containment and route resolution. This separation prevents a correct candidate from being rejected merely because it is being tested before publication.
 
 ### Rendered state/action identifiers
 
@@ -159,11 +172,14 @@ Every rendered anchor with an `href` and every rendered button is expected to ha
 A rendered action must resolve to exactly one class:
 
 - `transitions` — a declared flow edge from one route/state to another;
-- `navigation` with class `global` or `utility`;
+- `navigation` — global or utility human navigation;
+- `resources` — same-site machine/resource endpoints such as `project.json`, `stable.json`, or other linked deterministic interfaces;
 - `handoffs` — approved external exits/references;
 - `exceptions` — narrow documented exceptions with a reason.
 
 A link/action that is rendered but unclassified fails validation.
+
+#### Navigation and `$self`
 
 By default, each declared `navigation` action is required on every required route. A project can narrow that requirement:
 
@@ -182,7 +198,41 @@ or mark the navigation declaration as classification-only:
 "required_on": false
 ```
 
-Required non-terminal routes must also render at least one valid internal transition/navigation action, so a declared recovery concept cannot hide a real rendered dead end.
+Utility links that remain on the current route, such as a skip link, use the special target `$self`:
+
+```json
+{
+  "action": "skip-main",
+  "class": "utility",
+  "to": "$self"
+}
+```
+
+A `$self` utility link proves the utility action exists, but it does **not** satisfy the recovery requirement for a non-terminal route. Required non-terminal routes must render at least one valid internal transition/navigation edge to another route/state.
+
+#### Same-site machine resources
+
+Machine/resource links are intentionally not modeled as human route states merely because they are clickable. Declare an exact project-relative path:
+
+```json
+{
+  "action": "machine-project",
+  "path": "/project.json"
+}
+```
+
+or a project-relative prefix:
+
+```json
+{
+  "action": "machine-release-data",
+  "path_prefix": "/releases/"
+}
+```
+
+`resources` are classification-only by default. Use `required_on` when a particular human route is contractually required to expose that machine interface.
+
+This distinction prevents ordinary machine endpoints from being mislabeled as exceptions and keeps the human flow graph focused on human states and journeys.
 
 ### Browser-required actions
 
@@ -234,13 +284,13 @@ This is intentionally conservative. Crawler-specific policies remain project-own
 
 ### machine-description discovery
 
-When `discovery.machine_description` is declared, each rendered route must advertise it with a `describedby` relation, for example:
+When `discovery.machine_description` is declared, the candidate must contain that machine-description resource and each rendered human route must advertise it with a `describedby` relation, for example:
 
 ```html
 <link rel="describedby" href="../surface.json">
 ```
 
-The validator resolves the link against the route canonical URL.
+The validator resolves the relation against the route's production canonical URL.
 
 ## External handoffs
 
@@ -266,7 +316,7 @@ or a prefix:
 
 When `handoff` is declared, rendered HTML must also expose the matching `data-surface-handoff` value.
 
-The validator rejects a declared internal action that exits the candidate site and a declared external handoff that unexpectedly stays on the candidate origin.
+The validator rejects a declared internal action/resource that exits the candidate site and a declared external handoff that unexpectedly stays on the candidate origin.
 
 ## Usage
 
@@ -295,7 +345,8 @@ It records:
 - contract schema;
 - production canonical base URL and candidate navigation base URL;
 - route and expected-transition counts;
-- observed classified edges;
+- observed classified human edges;
+- observed same-site machine/resources;
 - browser-required actions;
 - approved observed external handoffs;
 - sitemap route inventory;
@@ -320,6 +371,7 @@ Any later production mutation such as IndexNow notification should remain a sepa
 This validator does not:
 
 - decide project routes or critical journeys;
+- turn every linked machine endpoint into a human flow state;
 - infer actions from CSS/pixel position/visible copy;
 - execute JavaScript;
 - certify WCAG compliance;

--- a/docs/public-surface-conformance.md
+++ b/docs/public-surface-conformance.md
@@ -290,7 +290,7 @@ When `discovery.machine_description` is declared, the candidate must contain tha
 <link rel="describedby" href="../surface.json">
 ```
 
-The validator resolves the relation against the route's production canonical URL.
+During candidate qualification, the validator resolves that relation against the candidate page/navigation base so it proves the candidate's own machine description rather than a previously deployed copy. On the production build, the same relative relation resolves under the production project base. Canonical URLs remain independently checked against `production_base_url`.
 
 ## External handoffs
 

--- a/docs/public-surface-conformance.md
+++ b/docs/public-surface-conformance.md
@@ -1,0 +1,287 @@
+# Public-surface model and discovery conformance
+
+`validate-surface-contract.py` is a public-safe, dependency-free validator for the cheap deterministic portion of `GOV-WEB-001` public-surface conformance.
+
+It does **not** replace Playwright, axe, Lighthouse, Lychee, or project-specific journey tests. Its job is to reject structurally inconsistent candidate surfaces before expensive browser execution.
+
+## Separation of responsibility
+
+The consumer repository owns:
+
+- route/state identities;
+- critical flow transitions;
+- global/utility navigation actions;
+- approved external handoffs;
+- indexability decisions;
+- canonical production base URL;
+- generated candidate bytes;
+- browser-executed JS transitions and critical user journeys.
+
+This reusable validator owns only generic checks over those declared inputs.
+
+The intended ordering is:
+
+```text
+consumer contract + generated candidate bytes
+        -> static/model/discovery validator
+        -> Playwright/axe
+        -> Lighthouse/Lychee as applicable
+        -> deployment
+        -> deployed smoke
+```
+
+## Contract schema
+
+Current schema:
+
+```text
+public-surface-contract/1
+```
+
+Minimal example:
+
+```json
+{
+  "schema": "public-surface-contract/1",
+  "production_base_url": "https://example.org/project/",
+  "entry_states": ["home"],
+  "routes": [
+    {
+      "id": "home",
+      "path": "/",
+      "title": "Example Project",
+      "indexable": true,
+      "required": true,
+      "terminal": false
+    },
+    {
+      "id": "guide",
+      "path": "/guide/",
+      "title": "Example Project Guide",
+      "indexable": true,
+      "required": true,
+      "terminal": false
+    }
+  ],
+  "transitions": [
+    {
+      "from": "home",
+      "action": "open-guide",
+      "to": "guide",
+      "required_rendered": true
+    }
+  ],
+  "navigation": [
+    {
+      "action": "nav-home",
+      "class": "global",
+      "to": "home"
+    }
+  ],
+  "handoffs": [
+    {
+      "action": "view-source",
+      "handoff": "source",
+      "url_prefix": "https://github.com/example/"
+    }
+  ],
+  "discovery": {
+    "sitemap": "sitemap.xml",
+    "robots": "robots.txt",
+    "machine_description": "surface.json"
+  }
+}
+```
+
+### Route paths
+
+`routes[].path` is relative to the declared project-site root even though it starts with `/`.
+
+For:
+
+```text
+production_base_url = https://example.org/project/
+path                = /guide/
+```
+
+the canonical production URL is:
+
+```text
+https://example.org/project/guide/
+```
+
+This avoids treating GitHub Pages project sites as origin-root sites.
+
+### Rendered state/action identifiers
+
+The rendered page declares its route/state identity:
+
+```html
+<main data-surface-state="home">
+```
+
+Rendered interactive links/actions receive a stable identifier:
+
+```html
+<a href="guide/" data-surface-action="open-guide">Guide</a>
+```
+
+These attributes are **supplemental machine identifiers**. They do not replace native HTML elements, accessible names, ARIA semantics, visible labels, or keyboard behavior.
+
+Every rendered anchor with an `href` and every rendered button is expected to have a `data-surface-action` classification when this validator is applied.
+
+### Action classes
+
+A rendered action must resolve to exactly one class:
+
+- `transitions` — a declared flow edge from one route/state to another;
+- `navigation` with class `global` or `utility`;
+- `handoffs` — approved external exits/references;
+- `exceptions` — narrow documented exceptions with a reason.
+
+A link/action that is rendered but unclassified fails validation.
+
+### Browser-required actions
+
+A JS-only action can be declared:
+
+```json
+{
+  "from": "home",
+  "action": "open-dialog",
+  "to": "dialog",
+  "browser_required": true
+}
+```
+
+The static validator records the action as requiring browser evidence rather than pretending to execute JavaScript. The consumer's Playwright suite remains authoritative for the actual transition.
+
+## Discovery checks
+
+For each declared indexable route, the validator requires:
+
+- candidate HTML exists;
+- exactly one matching `data-surface-state`;
+- exact expected `<title>`;
+- exactly one canonical link matching the production URL;
+- no accidental `noindex`;
+- inclusion in `sitemap.xml`.
+
+The sitemap must contain exactly the declared indexable canonical routes.
+
+### `lastmod`
+
+`lastmod` is optional.
+
+When a route declares:
+
+```json
+"lastmod": "2026-08-30"
+```
+
+the sitemap must contain that exact value.
+
+When the route does **not** declare `lastmod`, the sitemap must not invent one. This prevents build-wall-clock timestamps from masquerading as content modification history.
+
+### robots.txt
+
+The validator requires `robots.txt` to advertise the canonical sitemap URL and rejects a `User-agent: *` rule that blocks the entire origin or declared project base path.
+
+This is intentionally conservative. Crawler-specific policies remain project-owned data and should come only from authoritative provider documentation.
+
+### machine-description discovery
+
+When `discovery.machine_description` is declared, each rendered route must advertise it with a `describedby` relation, for example:
+
+```html
+<link rel="describedby" href="../surface.json">
+```
+
+The validator resolves the link against the route canonical URL.
+
+## External handoffs
+
+A handoff may require an exact URL:
+
+```json
+{
+  "action": "download-release",
+  "handoff": "artifact-download",
+  "url": "https://example.net/exact-artifact.jar"
+}
+```
+
+or a prefix:
+
+```json
+{
+  "action": "view-source",
+  "handoff": "source",
+  "url_prefix": "https://github.com/example/project"
+}
+```
+
+When `handoff` is declared, rendered HTML must also expose the matching `data-surface-handoff` value.
+
+The validator rejects a declared internal action that exits the site and a declared external handoff that unexpectedly stays on the same origin.
+
+## Usage
+
+```bash
+python3 scripts/public-web/validate-surface-contract.py \
+  --contract ./PUBLIC_SURFACE.json \
+  --site-dir ./build/public-site \
+  --evidence ./build/public-surface-conformance.json
+```
+
+Exit status is nonzero on failure. Evidence is deterministic for unchanged contract/candidate inputs except for external run metadata supplied separately by a caller.
+
+A consumer using `.github/workflows/public-site-readiness.yml` can invoke this from its existing deterministic `validate_command`, or pin/download the script as a separate read-only step. Project browser tests remain local.
+
+## Evidence format
+
+Current evidence schema:
+
+```text
+public-surface-conformance-evidence/1
+```
+
+It records:
+
+- contract schema;
+- production base URL;
+- route and expected-transition counts;
+- observed classified edges;
+- browser-required actions;
+- approved observed external handoffs;
+- sitemap route inventory;
+- warnings/errors;
+- overall verdict.
+
+Consumers should bind the evidence to their exact source revision and the immutable validator revision in their surrounding CI/provenance record.
+
+## R4 properties
+
+The validator is:
+
+- **reproducible** — exact candidate + exact contract + exact validator revision determine the verdict;
+- **repeatable** — it can be rerun by a fresh actor without chat/session state;
+- **reversible** — read-only, so no rollback is required;
+- **idempotent** — unchanged inputs yield the same state assessment/verdict.
+
+Any later production mutation such as IndexNow notification should remain a separate `Discover -> Plan -> Act -> Verify` mechanism with deduplication, receipts, and post-action verification.
+
+## Non-goals
+
+This validator does not:
+
+- decide project routes or critical journeys;
+- infer actions from CSS/pixel position/visible copy;
+- execute JavaScript;
+- certify WCAG compliance;
+- replace accessibility review;
+- replace Lychee resource integrity;
+- publish IndexNow notifications;
+- maintain a central route registry;
+- depend on private brand governance;
+- implement crawler-specific cloaking or speculative bot lists.

--- a/docs/public-surface-conformance.md
+++ b/docs/public-surface-conformance.md
@@ -2,7 +2,7 @@
 
 `validate-surface-contract.py` is a public-safe, dependency-free validator for the cheap deterministic portion of `GOV-WEB-001` public-surface conformance.
 
-It does **not** replace Playwright, axe, Lighthouse, Lychee, or project-specific journey tests. Its job is to reject structurally inconsistent candidate surfaces before expensive browser execution.
+It does **not** replace Playwright, axe, Lighthouse, Lychee, deployed smoke, or project-specific journey tests. Its job is to reject structurally inconsistent candidate surfaces before expensive browser execution.
 
 ## Separation of responsibility
 
@@ -14,13 +14,14 @@ The consumer repository owns:
 - same-site machine/resource endpoints exposed as links;
 - approved external handoffs;
 - indexability decisions;
-- canonical production base URL;
+- canonical production identity;
+- crawler-policy applicability/authority;
 - generated candidate bytes;
-- browser-executed JS transitions and critical user journeys.
+- browser-executed JavaScript transitions and critical user journeys.
 
-This reusable validator owns only generic checks over those declared inputs.
+The reusable validator owns generic checks over those declared inputs.
 
-The intended ordering is:
+The intended order is:
 
 ```text
 consumer contract + generated candidate bytes
@@ -28,7 +29,7 @@ consumer contract + generated candidate bytes
         -> Playwright/axe
         -> Lighthouse/Lychee as applicable
         -> deployment
-        -> deployed smoke
+        -> deployed smoke/live authority checks
 ```
 
 ## Contract schema
@@ -39,7 +40,7 @@ Current schema:
 public-surface-contract/1
 ```
 
-Minimal example:
+A subpath-hosted example:
 
 ```json
 {
@@ -100,13 +101,16 @@ Minimal example:
   ],
   "discovery": {
     "sitemap": "sitemap.xml",
-    "robots": "robots.txt",
+    "robots": {
+      "mode": "origin-external",
+      "url": "https://example.org/robots.txt"
+    },
     "machine_description": "surface.json"
   }
 }
 ```
 
-### Route paths
+## Route identity
 
 `routes[].path` is relative to the declared project-site root even though it starts with `/`.
 
@@ -123,82 +127,72 @@ the canonical production URL is:
 https://example.org/project/guide/
 ```
 
-This avoids treating GitHub Pages project sites as origin-root sites.
+This prevents GitHub Pages project sites from being accidentally treated as origin-root sites.
 
-### Production identity versus candidate navigation identity
+## Production identity versus candidate navigation identity
 
-`production_base_url` is the canonical/indexing identity. It is **not** assumed to be the URL used by the local candidate server.
+`production_base_url` is the canonical/indexing identity. It is not assumed to be the address used by the local candidate server.
 
-For example, Bridge can be generated with canonical URLs under:
+For example, candidate bytes may carry canonical URLs under:
 
 ```text
 https://supracraft.github.io/Bridge/
 ```
 
-while browser qualification serves the exact candidate at:
+while qualification serves those exact bytes at:
 
 ```text
 http://127.0.0.1:4173/
 ```
 
-Pass that ephemeral candidate identity with:
+Pass the candidate navigation identity explicitly:
 
-```text
+```bash
 --navigation-base http://127.0.0.1:4173/
 ```
 
-The validator uses the production base for canonical/Sitemap/robots checks and the navigation base for rendered internal-link/resource containment and route resolution. This separation prevents a correct candidate from being rejected merely because it is being tested before publication.
+The validator uses:
 
-### Rendered state/action identifiers
+- the **production base** for canonical URLs and Sitemap entries;
+- the **candidate navigation base** for rendered internal navigation, same-site resources, and candidate `describedby` resolution.
 
-The rendered page declares its route/state identity:
+This ensures pre-deployment qualification validates the candidate rather than yesterday's deployed surface.
+
+## Rendered state/action identifiers
+
+A rendered human page declares its state identity:
 
 ```html
 <main data-surface-state="home">
 ```
 
-Rendered interactive links/actions receive a stable identifier:
+Rendered interactive links/actions use stable supplemental identifiers:
 
 ```html
 <a href="guide/" data-surface-action="open-guide">Guide</a>
 ```
 
-These attributes are **supplemental machine identifiers**. They do not replace native HTML elements, accessible names, ARIA semantics, visible labels, or keyboard behavior.
+These attributes do not replace native HTML, visible labels, accessible names, ARIA semantics, or keyboard behavior. They exist to make the same interface understandable to deterministic automation and agents without reverse-engineering CSS or position.
 
-Every rendered anchor with an `href` and every rendered button is expected to have a `data-surface-action` classification when this validator is applied.
+When this validator is applied, every rendered anchor with `href` and every rendered button must be classified by `data-surface-action`.
 
-### Action classes
+## Action classes
 
-A rendered action must resolve to exactly one class:
+A rendered action resolves to exactly one class:
 
-- `transitions` — a declared flow edge from one route/state to another;
+- `transitions` — declared human-flow edges;
 - `navigation` — global or utility human navigation;
-- `resources` — same-site machine/resource endpoints such as `project.json`, `stable.json`, or other linked deterministic interfaces;
+- `resources` — linked same-site machine/resource endpoints;
 - `handoffs` — approved external exits/references;
 - `exceptions` — narrow documented exceptions with a reason.
 
-A link/action that is rendered but unclassified fails validation.
+Rendered-but-unclassified actions fail validation.
 
-#### Navigation and `$self`
+### Navigation and `$self`
 
-By default, each declared `navigation` action is required on every required route. A project can narrow that requirement:
+By default, declared navigation is expected on all required routes. `required_on` may narrow the set, or `false` may make a declaration classification-only.
 
-```json
-{
-  "action": "nav-releases",
-  "class": "global",
-  "to": "releases",
-  "required_on": ["home", "guide", "releases"]
-}
-```
-
-or mark the navigation declaration as classification-only:
-
-```json
-"required_on": false
-```
-
-Utility links that remain on the current route, such as a skip link, use the special target `$self`:
+Same-page utility actions such as a skip link use `$self`:
 
 ```json
 {
@@ -208,11 +202,11 @@ Utility links that remain on the current route, such as a skip link, use the spe
 }
 ```
 
-A `$self` utility link proves the utility action exists, but it does **not** satisfy the recovery requirement for a non-terminal route. Required non-terminal routes must render at least one valid internal transition/navigation edge to another route/state.
+A `$self` action proves that utility behavior exists but does not satisfy the recovery requirement for a non-terminal state. A required non-terminal route must expose a valid continuation/recovery edge to another route/state.
 
-#### Same-site machine resources
+### Same-site machine resources
 
-Machine/resource links are intentionally not modeled as human route states merely because they are clickable. Declare an exact project-relative path:
+Machine endpoints remain distinct from human-flow states. Declare an exact project-relative path:
 
 ```json
 {
@@ -221,7 +215,7 @@ Machine/resource links are intentionally not modeled as human route states merel
 }
 ```
 
-or a project-relative prefix:
+or prefix:
 
 ```json
 {
@@ -230,13 +224,11 @@ or a project-relative prefix:
 }
 ```
 
-`resources` are classification-only by default. Use `required_on` when a particular human route is contractually required to expose that machine interface.
-
-This distinction prevents ordinary machine endpoints from being mislabeled as exceptions and keeps the human flow graph focused on human states and journeys.
+Resources are classification-only by default. `required_on` makes exposure from specific human routes part of the contract.
 
 ### Browser-required actions
 
-A JS-only action can be declared:
+A transition that cannot be proven statically can declare:
 
 ```json
 {
@@ -247,76 +239,94 @@ A JS-only action can be declared:
 }
 ```
 
-The static validator records the action as requiring browser evidence rather than pretending to execute JavaScript. The consumer's Playwright suite remains authoritative for the actual transition.
+The validator records that browser evidence is required; consumer-owned Playwright remains authoritative for execution.
 
 ## Discovery checks
 
-For each declared indexable route, the validator requires:
+For each declared indexable human route, the validator requires:
 
 - candidate HTML exists;
 - exactly one matching `data-surface-state`;
 - exact expected `<title>`;
-- exactly one canonical link matching the production URL;
+- exactly one canonical URL matching the production identity;
 - no accidental `noindex`;
-- inclusion in `sitemap.xml`.
+- presence in `sitemap.xml`.
 
-The sitemap must contain exactly the declared indexable canonical routes.
+The Sitemap must contain exactly the declared indexable canonical routes.
 
-### `lastmod`
+### Truthful `lastmod`
 
-`lastmod` is optional.
+`lastmod` is optional. If a route declares an authoritative value, the Sitemap must contain that exact value. If the route does not declare one, the Sitemap must not invent one from build time.
 
-When a route declares:
+This keeps source/content history separate from CI wall-clock time.
+
+## robots.txt authority
+
+Robots Exclusion Protocol authority is origin-scoped, so the contract makes ownership explicit instead of assuming every project can generate a meaningful project-local file.
+
+### Origin-root surface: `local`
+
+A site that owns the origin root may validate its candidate `/robots.txt`:
 
 ```json
-"lastmod": "2026-08-30"
+"robots": {
+  "mode": "local",
+  "path": "robots.txt"
+}
 ```
 
-the sitemap must contain that exact value.
+`local` is valid only when `production_base_url` is the origin root, such as:
 
-When the route does **not** declare `lastmod`, the sitemap must not invent one. This prevents build-wall-clock timestamps from masquerading as content modification history.
+```text
+https://example.org/
+```
 
-### robots.txt
+The validator checks that candidate `robots.txt` advertises the canonical Sitemap and does not globally disallow `User-agent: *`.
 
-The validator requires `robots.txt` to advertise the canonical sitemap URL and rejects a `User-agent: *` rule that blocks the entire origin or declared project base path.
+### Shared-origin/subpath surface: `origin-external`
 
-This is intentionally conservative. Crawler-specific policies remain project-owned data and should come only from authoritative provider documentation.
+A project site such as:
 
-### machine-description discovery
+```text
+https://supracraft.github.io/Bridge/
+```
 
-When `discovery.machine_description` is declared, the candidate must contain that machine-description resource and each rendered human route must advertise it with a `describedby` relation, for example:
+does not own:
+
+```text
+https://supracraft.github.io/robots.txt
+```
+
+It must therefore declare origin-level authority explicitly:
+
+```json
+"robots": {
+  "mode": "origin-external",
+  "url": "https://supracraft.github.io/robots.txt"
+}
+```
+
+Candidate validation verifies that the declared URL is exactly the production origin's `/robots.txt`, then records robots verification as `deferred-live`. The actual origin policy belongs in deployed/live verification or in the repository that owns the origin-root site.
+
+Do **not** generate `/Bridge/robots.txt` and call it the site's REP authority; a tidy but non-authoritative file is worse than an explicit applicability boundary.
+
+Crawler-specific policy remains project-owned data and should use identities published by authoritative providers rather than speculative bot lists.
+
+## Machine-description discovery
+
+When `discovery.machine_description` is declared, the candidate must contain it and every rendered human route must advertise it with a `describedby` relation:
 
 ```html
 <link rel="describedby" href="../surface.json">
 ```
 
-During candidate qualification, the validator resolves that relation against the candidate page/navigation base so it proves the candidate's own machine description rather than a previously deployed copy. On the production build, the same relative relation resolves under the production project base. Canonical URLs remain independently checked against `production_base_url`.
+During candidate qualification this resolves against the candidate page/navigation base, proving the candidate's own machine description. In production the same relative relation resolves under the production project base.
 
 ## External handoffs
 
-A handoff may require an exact URL:
+A handoff can require an exact URL or a URL prefix. When a handoff identity is declared, rendered HTML must expose the matching `data-surface-handoff` value.
 
-```json
-{
-  "action": "download-release",
-  "handoff": "artifact-download",
-  "url": "https://example.net/exact-artifact.jar"
-}
-```
-
-or a prefix:
-
-```json
-{
-  "action": "view-source",
-  "handoff": "source",
-  "url_prefix": "https://github.com/example/project"
-}
-```
-
-When `handoff` is declared, rendered HTML must also expose the matching `data-surface-handoff` value.
-
-The validator rejects a declared internal action/resource that exits the candidate site and a declared external handoff that unexpectedly stays on the candidate origin.
+The validator rejects internal transitions/resources that escape the candidate site and external handoffs that unexpectedly remain inside it.
 
 ## Usage
 
@@ -328,53 +338,52 @@ python3 scripts/public-web/validate-surface-contract.py \
   --evidence ./build/public-surface-conformance.json
 ```
 
-Exit status is nonzero on failure. Evidence is deterministic for unchanged contract/candidate inputs except for external run metadata supplied separately by a caller.
+A consumer of `.github/workflows/public-site-readiness.yml` may invoke this from its deterministic `validate_command` or as a separate pinned read-only step. Project browser tests remain local.
 
-A consumer using `.github/workflows/public-site-readiness.yml` can invoke this from its existing deterministic `validate_command`, or pin/download the script as a separate read-only step. Project browser tests remain local.
+## Evidence
 
-## Evidence format
-
-Current evidence schema:
+Current schema:
 
 ```text
 public-surface-conformance-evidence/1
 ```
 
-It records:
+Evidence includes:
 
 - contract schema;
-- production canonical base URL and candidate navigation base URL;
+- production base and candidate navigation base;
 - route and expected-transition counts;
 - observed classified human edges;
-- observed same-site machine/resources;
+- observed same-site machine resources;
 - browser-required actions;
-- approved observed external handoffs;
-- sitemap route inventory;
+- approved external handoffs;
+- Sitemap inventory;
+- robots authority mode, URL, and whether verification is candidate or deferred-live;
 - warnings/errors;
-- overall verdict.
+- overall deterministic verdict.
 
-Consumers should bind the evidence to their exact source revision and the immutable validator revision in their surrounding CI/provenance record.
+Consumers should bind this evidence to exact consumer source and immutable validator identities in surrounding CI/provenance.
 
 ## R4 properties
 
 The validator is:
 
-- **reproducible** — exact candidate + exact contract + exact validator revision determine the verdict;
-- **repeatable** — it can be rerun by a fresh actor without chat/session state;
-- **reversible** — read-only, so no rollback is required;
-- **idempotent** — unchanged inputs yield the same state assessment/verdict.
+- **reproducible** — exact candidate + contract + validator revision determine the verdict;
+- **repeatable** — a fresh actor can rerun it without session state;
+- **reversible** — it is read-only, so no rollback is required;
+- **idempotent** — unchanged inputs produce the same assessment/verdict.
 
-Any later production mutation such as IndexNow notification should remain a separate `Discover -> Plan -> Act -> Verify` mechanism with deduplication, receipts, and post-action verification.
+Future production mutations such as IndexNow remain separate `Discover -> Plan -> Act -> Verify` mechanisms with deduplication, receipts, and post-action verification.
 
 ## Non-goals
 
 This validator does not:
 
 - decide project routes or critical journeys;
-- turn every linked machine endpoint into a human flow state;
-- infer actions from CSS/pixel position/visible copy;
+- turn every machine endpoint into a human state;
+- infer actions from CSS, pixels, or visible copy;
 - execute JavaScript;
-- certify WCAG compliance;
+- certify WCAG conformance;
 - replace accessibility review;
 - replace Lychee resource integrity;
 - publish IndexNow notifications;

--- a/scripts/public-web/validate-surface-contract.py
+++ b/scripts/public-web/validate-surface-contract.py
@@ -17,6 +17,7 @@ from urllib.parse import urljoin, urlparse, urlunparse
 
 CONTRACT_SCHEMA = "public-surface-contract/1"
 EVIDENCE_SCHEMA = "public-surface-conformance-evidence/1"
+SELF = "$self"
 
 
 class ValidationError(Exception):
@@ -82,7 +83,7 @@ class PageParser(HTMLParser):
         return " ".join("".join(self._title).split())
 
 
-def error(errors: list[str], message: str) -> None:
+def add_error(errors: list[str], message: str) -> None:
     errors.append(message)
 
 
@@ -96,12 +97,12 @@ def norm_base(value: str, field: str) -> str:
     return urlunparse((p.scheme, p.netloc, path, "", "", ""))
 
 
-def norm_route(value: Any) -> str:
+def norm_project_path(value: Any) -> str:
     if not isinstance(value, str) or not value.startswith("/"):
-        raise ValidationError(f"route path must start with '/': {value!r}")
+        raise ValidationError(f"project path must start with '/': {value!r}")
     p = urlparse(value)
     if p.scheme or p.netloc or p.query or p.fragment:
-        raise ValidationError(f"route path must be path-only: {value!r}")
+        raise ValidationError(f"project path must be path-only: {value!r}")
     raw = re.sub(r"/+", "/", p.path)
     norm = posixpath.normpath(raw)
     if not norm.startswith("/"):
@@ -111,8 +112,8 @@ def norm_route(value: Any) -> str:
     return norm
 
 
-def project_url(base: str, route_path: str) -> str:
-    return urljoin(base, route_path.lstrip("/"))
+def project_url(base: str, project_path: str) -> str:
+    return urljoin(base, project_path.lstrip("/"))
 
 
 def route_file(site_dir: Path, path: str) -> Path:
@@ -158,7 +159,7 @@ def load_routes(contract: dict[str, Any]) -> tuple[list[Route], dict[str, Route]
             raise ValidationError("route id must be a non-empty string")
         if not isinstance(title, str) or not title.strip():
             raise ValidationError(f"route {rid!r} requires an exact expected title")
-        path = norm_route(raw.get("path"))
+        path = norm_project_path(raw.get("path"))
         if rid in by_id or path in by_path:
             raise ValidationError(f"duplicate route id/path: {rid!r} {path!r}")
         lastmod = raw.get("lastmod")
@@ -184,9 +185,11 @@ def load_action_contract(
     dict[str, dict[str, Any]],
     dict[str, dict[str, Any]],
     dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
 ]:
     transitions: dict[tuple[str, str], dict[str, Any]] = {}
     navigation: dict[str, dict[str, Any]] = {}
+    resources: dict[str, dict[str, Any]] = {}
     handoffs: dict[str, dict[str, Any]] = {}
     exceptions: dict[str, dict[str, Any]] = {}
 
@@ -205,11 +208,34 @@ def load_action_contract(
         if not isinstance(item, dict):
             raise ValidationError("navigation entries must be objects")
         action, target, cls = item.get("action"), item.get("to"), item.get("class")
-        if not isinstance(action, str) or not action or target not in by_id or cls not in {"global", "utility"}:
+        if (
+            not isinstance(action, str) or not action
+            or (target != SELF and target not in by_id)
+            or cls not in {"global", "utility"}
+        ):
             raise ValidationError(f"invalid navigation: {item!r}")
         if action in navigation:
             raise ValidationError(f"duplicate navigation action {action!r}")
         navigation[action] = item
+
+    for item in contract.get("resources", []):
+        if not isinstance(item, dict):
+            raise ValidationError("resource entries must be objects")
+        action = item.get("action")
+        exact, prefix = item.get("path"), item.get("path_prefix")
+        if not isinstance(action, str) or not action:
+            raise ValidationError(f"invalid resource action: {item!r}")
+        if bool(exact) == bool(prefix):
+            raise ValidationError(f"resource {action!r} requires exactly one of path/path_prefix")
+        if exact:
+            item = dict(item)
+            item["path"] = norm_project_path(exact)
+        if prefix:
+            item = dict(item)
+            item["path_prefix"] = norm_project_path(prefix)
+        if action in resources:
+            raise ValidationError(f"duplicate resource action {action!r}")
+        resources[action] = item
 
     for item in contract.get("handoffs", []):
         if not isinstance(item, dict):
@@ -234,12 +260,17 @@ def load_action_contract(
         exceptions[action] = item
 
     seen: dict[str, str] = {}
-    for kind, mapping in [("navigation", navigation), ("handoff", handoffs), ("exception", exceptions)]:
+    for kind, mapping in [
+        ("navigation", navigation),
+        ("resource", resources),
+        ("handoff", handoffs),
+        ("exception", exceptions),
+    ]:
         for action in mapping:
             if action in seen:
                 raise ValidationError(f"action {action!r} appears in both {seen[action]} and {kind}")
             seen[action] = kind
-    return transitions, navigation, handoffs, exceptions
+    return transitions, navigation, resources, handoffs, exceptions
 
 
 def check_model(
@@ -252,14 +283,15 @@ def check_model(
 ) -> None:
     entries = contract.get("entry_states")
     if not isinstance(entries, list) or not entries or any(e not in by_id for e in entries):
-        error(errors, "entry_states must be a non-empty list of declared route ids")
+        add_error(errors, "entry_states must be a non-empty list of declared route ids")
         return
     graph: dict[str, set[str]] = defaultdict(set)
     for (src, _), item in transitions.items():
         graph[src].add(item["to"])
     for src in by_id:
         for item in navigation.values():
-            graph[src].add(item["to"])
+            target = src if item["to"] == SELF else item["to"]
+            graph[src].add(target)
     seen: set[str] = set()
     queue = deque(entries)
     while queue:
@@ -270,7 +302,7 @@ def check_model(
         queue.extend(sorted(graph[current] - seen))
     for route in routes:
         if route.required and route.id not in seen:
-            error(errors, f"required route/state {route.id!r} is unreachable from entry_states")
+            add_error(errors, f"required route/state {route.id!r} is unreachable from entry_states")
 
 
 def parse_sitemap(path: Path) -> dict[str, str | None]:
@@ -330,31 +362,36 @@ def same_origin_and_base(url: str, base: str) -> tuple[bool, bool]:
     return same_origin, same_origin and (u.path == base_path[:-1] or u.path.startswith(base_path))
 
 
-def target_route(url: str, navigation_base: str, by_path: dict[str, Route]) -> str | None:
-    u, b = urlparse(url), urlparse(navigation_base)
+def project_path_for_url(url: str, base: str) -> str | None:
+    u, b = urlparse(url), urlparse(base)
     base_path = b.path if b.path.endswith("/") else b.path + "/"
-    if not (u.path == base_path[:-1] or u.path.startswith(base_path)):
+    if u.path == base_path[:-1]:
+        return "/"
+    if not u.path.startswith(base_path):
         return None
-    rel = "" if u.path == base_path[:-1] else u.path[len(base_path):]
-    path = norm_route("/" + rel)
+    return norm_project_path("/" + u.path[len(base_path):])
+
+
+def target_route(url: str, navigation_base: str, by_path: dict[str, Route]) -> str | None:
+    path = project_path_for_url(url, navigation_base)
+    if path is None:
+        return None
     route = by_path.get(path)
     return route.id if route else None
 
 
-def required_sources(item: dict[str, Any], routes: list[Route]) -> set[str]:
+def required_sources(item: dict[str, Any], routes: list[Route], default_all: bool) -> set[str]:
     raw = item.get("required_on")
     if raw is None:
-        return {route.id for route in routes if route.required}
+        return {route.id for route in routes if route.required} if default_all else set()
     if raw is False:
         return set()
     if not isinstance(raw, list) or any(not isinstance(v, str) for v in raw):
-        raise ValidationError("navigation required_on must be false or a list of route ids")
+        raise ValidationError("required_on must be false or a list of route ids")
     return set(raw)
 
 
-def validate(
-    contract_path: Path, site_dir: Path, navigation_base_url: str | None = None
-) -> dict[str, Any]:
+def validate(contract_path: Path, site_dir: Path, navigation_base_url: str | None = None) -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
     contract = read_json(contract_path)
@@ -362,11 +399,9 @@ def validate(
         raise ValidationError(f"contract schema must be {CONTRACT_SCHEMA!r}")
 
     production_base = norm_base(contract.get("production_base_url", ""), "production_base_url")
-    navigation_base = norm_base(
-        navigation_base_url or production_base, "navigation_base_url"
-    )
+    navigation_base = norm_base(navigation_base_url or production_base, "navigation_base_url")
     routes, by_id, by_path = load_routes(contract)
-    transitions, navigation, handoffs, exceptions = load_action_contract(contract, by_id)
+    transitions, navigation, resources, handoffs, exceptions = load_action_contract(contract, by_id)
     check_model(contract, routes, by_id, transitions, navigation, errors)
 
     discovery = contract.get("discovery") or {}
@@ -384,74 +419,86 @@ def validate(
     missing = sorted(set(expected_sitemap) - set(actual_sitemap))
     unexpected = sorted(set(actual_sitemap) - set(expected_sitemap))
     if missing:
-        error(errors, f"sitemap missing indexable canonical routes: {missing}")
+        add_error(errors, f"sitemap missing indexable canonical routes: {missing}")
     if unexpected:
-        error(errors, f"sitemap contains undeclared/non-indexable routes: {unexpected}")
+        add_error(errors, f"sitemap contains undeclared/non-indexable routes: {unexpected}")
     for loc in sorted(set(expected_sitemap) & set(actual_sitemap)):
         if expected_sitemap[loc] != actual_sitemap[loc]:
-            error(errors, f"sitemap lastmod mismatch for {loc}: expected {expected_sitemap[loc]!r}, got {actual_sitemap[loc]!r}")
+            add_error(errors, f"sitemap lastmod mismatch for {loc}: expected {expected_sitemap[loc]!r}, got {actual_sitemap[loc]!r}")
 
     sitemap_url = urljoin(production_base, sitemap_rel)
     robot_sitemaps, robot_directives = parse_robots(site_dir / robots_rel)
     if sitemap_url not in robot_sitemaps:
-        error(errors, f"robots.txt must advertise canonical sitemap URL {sitemap_url}")
+        add_error(errors, f"robots.txt must advertise canonical sitemap URL {sitemap_url}")
     production_path = urlparse(production_base).path
     for agent, kind, value in robot_directives:
         if agent == "*" and kind == "disallow" and value in {"/", production_path, production_path.rstrip("/")}:
-            error(errors, f"robots.txt blocks production site for User-agent *: Disallow: {value}")
+            add_error(errors, f"robots.txt blocks production site for User-agent *: Disallow: {value}")
+
+    if machine_rel and not urlparse(machine_rel).scheme:
+        machine_path = site_dir / machine_rel.lstrip("/")
+        if not machine_path.exists():
+            add_error(errors, f"declared machine description does not exist in candidate bytes: {machine_path}")
 
     observed_edges: list[dict[str, str]] = []
+    observed_resources: list[dict[str, str]] = []
     observed_handoffs: list[dict[str, str]] = []
     browser_required: list[dict[str, str]] = []
     seen_transitions: set[tuple[str, str]] = set()
     seen_navigation: set[tuple[str, str]] = set()
-    internal_outgoing: dict[str, int] = defaultdict(int)
+    seen_resources: set[tuple[str, str]] = set()
+    recovery_edges: dict[str, int] = defaultdict(int)
 
     for route in routes:
         page_path = route_file(site_dir, route.path)
         if not page_path.exists():
             if route.required:
-                error(errors, f"missing required rendered route {route.id!r}: {page_path}")
+                add_error(errors, f"missing required rendered route {route.id!r}: {page_path}")
             continue
         page = parse_page(page_path)
         canonical = project_url(production_base, route.path)
         candidate_page = project_url(navigation_base, route.path)
 
         if page.states != [route.id]:
-            error(errors, f"{route.id}: expected exactly data-surface-state={route.id!r}, observed {page.states!r}")
+            add_error(errors, f"{route.id}: expected exactly data-surface-state={route.id!r}, observed {page.states!r}")
         if page.title != route.title:
-            error(errors, f"{route.id}: title mismatch: expected {route.title!r}, got {page.title!r}")
+            add_error(errors, f"{route.id}: title mismatch: expected {route.title!r}, got {page.title!r}")
         if page.canonicals != [canonical]:
-            error(errors, f"{route.id}: expected exactly canonical {canonical!r}, observed {page.canonicals!r}")
+            add_error(errors, f"{route.id}: expected exactly canonical {canonical!r}, observed {page.canonicals!r}")
         noindex = any(
             "noindex" in {token.strip().lower() for token in value.split(",")}
             for value in page.robots
         )
         if route.indexable and noindex:
-            error(errors, f"{route.id}: indexable route is marked noindex")
+            add_error(errors, f"{route.id}: indexable route is marked noindex")
         if not route.indexable and not noindex:
             warnings.append(f"{route.id}: non-indexable route does not explicitly declare noindex")
 
         if machine_rel:
-            expected_machine = urljoin(canonical, machine_rel) if machine_rel.startswith(".") else urljoin(production_base, machine_rel)
+            expected_machine = (
+                urljoin(canonical, machine_rel)
+                if machine_rel.startswith(".")
+                else urljoin(production_base, machine_rel)
+            )
             resolved = {urljoin(canonical, href) for href in page.describedby}
             if expected_machine not in resolved:
-                error(errors, f"{route.id}: missing rel=describedby link to {expected_machine}")
+                add_error(errors, f"{route.id}: missing rel=describedby link to {expected_machine}")
 
         for rendered in page.actions:
             action, href, tag = rendered["action"], rendered["href"], rendered["tag"]
             if not action:
                 if (tag == "a" and href) or tag == "button":
-                    error(errors, f"{route.id}: rendered {tag} lacks data-surface-action classification")
+                    add_error(errors, f"{route.id}: rendered {tag} lacks data-surface-action classification")
                 continue
 
             transition = transitions.get((route.id, action))
             nav = navigation.get(action)
+            resource = resources.get(action)
             handoff = handoffs.get(action)
             exception = exceptions.get(action)
-            matches = sum(v is not None for v in (transition, nav, handoff, exception))
+            matches = sum(v is not None for v in (transition, nav, resource, handoff, exception))
             if matches != 1:
-                error(errors, f"{route.id}: rendered action {action!r} has {matches} declared classifications")
+                add_error(errors, f"{route.id}: rendered action {action!r} has {matches} declared classifications")
                 continue
             if exception:
                 continue
@@ -459,71 +506,101 @@ def validate(
             if href is None:
                 declared = transition or nav
                 if declared and bool(declared.get("browser_required", False)):
-                    target = declared["to"]
+                    raw_target = declared["to"]
+                    target = route.id if raw_target == SELF else raw_target
                     browser_required.append({"from": route.id, "action": action, "to": target})
-                    internal_outgoing[route.id] += 1
+                    if target != route.id:
+                        recovery_edges[route.id] += 1
                     if transition:
                         seen_transitions.add((route.id, action))
                     if nav:
                         seen_navigation.add((route.id, action))
                 else:
-                    error(errors, f"{route.id}: action {action!r} has no href and is not browser_required")
+                    add_error(errors, f"{route.id}: action {action!r} has no href and is not browser_required")
                 continue
 
             absolute = urljoin(candidate_page, href)
             same_origin, in_base = same_origin_and_base(absolute, navigation_base)
 
             if transition or nav:
-                target = (transition or nav)["to"]
+                raw_target = (transition or nav)["to"]
+                target = route.id if raw_target == SELF else raw_target
                 if same_origin and not in_base:
-                    error(errors, f"{route.id}: internal action {action!r} escapes candidate project base path: {absolute}")
+                    add_error(errors, f"{route.id}: internal action {action!r} escapes candidate project base path: {absolute}")
                     continue
                 if not same_origin:
-                    error(errors, f"{route.id}: internal action {action!r} unexpectedly exits candidate site: {absolute}")
+                    add_error(errors, f"{route.id}: internal action {action!r} unexpectedly exits candidate site: {absolute}")
                     continue
                 observed_target = target_route(absolute, navigation_base, by_path)
                 if observed_target != target:
-                    error(errors, f"{route.id}: action {action!r} targets {observed_target!r}/{absolute}, expected {target!r}")
+                    add_error(errors, f"{route.id}: action {action!r} targets {observed_target!r}/{absolute}, expected {target!r}")
                     continue
-                cls = "flow" if transition else nav["class"]
+                cls = "flow" if transition else (transition or nav)["class"]
                 observed_edges.append({"from": route.id, "action": action, "to": target, "class": cls})
-                internal_outgoing[route.id] += 1
+                if target != route.id:
+                    recovery_edges[route.id] += 1
                 if transition:
                     seen_transitions.add((route.id, action))
                 if nav:
                     seen_navigation.add((route.id, action))
                 continue
 
+            if resource:
+                if same_origin and not in_base:
+                    add_error(errors, f"{route.id}: resource action {action!r} escapes candidate project base path: {absolute}")
+                    continue
+                if not same_origin:
+                    add_error(errors, f"{route.id}: internal resource action {action!r} unexpectedly exits candidate site: {absolute}")
+                    continue
+                observed_path = project_path_for_url(absolute, navigation_base)
+                exact, prefix = resource.get("path"), resource.get("path_prefix")
+                if exact and observed_path != exact:
+                    add_error(errors, f"{route.id}: resource {action!r} path mismatch: {observed_path!r} != {exact!r}")
+                    continue
+                if prefix and (observed_path is None or not observed_path.startswith(prefix)):
+                    add_error(errors, f"{route.id}: resource {action!r} path {observed_path!r} does not match prefix {prefix!r}")
+                    continue
+                observed_resources.append({"from": route.id, "action": action, "path": observed_path or ""})
+                seen_resources.add((route.id, action))
+                continue
+
             if handoff:
                 if same_origin:
-                    error(errors, f"{route.id}: external handoff {action!r} unexpectedly stays on candidate origin: {absolute}")
+                    add_error(errors, f"{route.id}: external handoff {action!r} unexpectedly stays on candidate origin: {absolute}")
                     continue
                 exact, prefix = handoff.get("url"), handoff.get("url_prefix")
                 if exact and absolute != exact:
-                    error(errors, f"{route.id}: handoff {action!r} URL mismatch: {absolute!r} != {exact!r}")
+                    add_error(errors, f"{route.id}: handoff {action!r} URL mismatch: {absolute!r} != {exact!r}")
                     continue
                 if prefix and not absolute.startswith(prefix):
-                    error(errors, f"{route.id}: handoff {action!r} URL {absolute!r} does not match prefix {prefix!r}")
+                    add_error(errors, f"{route.id}: handoff {action!r} URL {absolute!r} does not match prefix {prefix!r}")
                     continue
                 if handoff.get("handoff") and rendered.get("handoff") != handoff["handoff"]:
-                    error(errors, f"{route.id}: handoff {action!r} requires data-surface-handoff={handoff['handoff']!r}")
+                    add_error(errors, f"{route.id}: handoff {action!r} requires data-surface-handoff={handoff['handoff']!r}")
                     continue
                 observed_handoffs.append({"from": route.id, "action": action, "url": absolute})
 
     for key, item in transitions.items():
         if bool(item.get("required_rendered", True)) and key not in seen_transitions:
-            error(errors, f"required rendered transition missing: {key[0]} --{key[1]}--> {item['to']}")
+            add_error(errors, f"required rendered transition missing: {key[0]} --{key[1]}--> {item['to']}")
 
     for action, item in navigation.items():
-        for source in required_sources(item, routes):
+        for source in required_sources(item, routes, default_all=True):
             if source not in by_id:
                 raise ValidationError(f"navigation {action!r} required_on references unknown route {source!r}")
             if (source, action) not in seen_navigation:
-                error(errors, f"required rendered {item['class']} navigation missing on {source!r}: {action!r}")
+                add_error(errors, f"required rendered {item['class']} navigation missing on {source!r}: {action!r}")
+
+    for action, item in resources.items():
+        for source in required_sources(item, routes, default_all=False):
+            if source not in by_id:
+                raise ValidationError(f"resource {action!r} required_on references unknown route {source!r}")
+            if (source, action) not in seen_resources:
+                add_error(errors, f"required rendered resource missing on {source!r}: {action!r}")
 
     for route in routes:
-        if route.required and not route.terminal and internal_outgoing[route.id] == 0:
-            error(errors, f"required non-terminal route/state {route.id!r} is a rendered dead end")
+        if route.required and not route.terminal and recovery_edges[route.id] == 0:
+            add_error(errors, f"required non-terminal route/state {route.id!r} is a rendered dead end")
 
     return {
         "schema": EVIDENCE_SCHEMA,
@@ -533,9 +610,11 @@ def validate(
         "route_count": len(routes),
         "expected_transition_count": len(transitions),
         "observed_edge_count": len(observed_edges),
+        "observed_resource_count": len(observed_resources),
         "observed_handoff_count": len(observed_handoffs),
         "browser_required_actions": sorted(browser_required, key=lambda v: (v["from"], v["action"], v["to"])),
         "observed_edges": sorted(observed_edges, key=lambda v: (v["from"], v["action"], v["to"])),
+        "internal_resources": sorted(observed_resources, key=lambda v: (v["from"], v["action"], v["path"])),
         "external_handoffs": sorted(observed_handoffs, key=lambda v: (v["from"], v["action"], v["url"])),
         "sitemap_routes": sorted(actual_sitemap),
         "warnings": sorted(warnings),

--- a/scripts/public-web/validate-surface-contract.py
+++ b/scripts/public-web/validate-surface-contract.py
@@ -475,14 +475,15 @@ def validate(contract_path: Path, site_dir: Path, navigation_base_url: str | Non
             warnings.append(f"{route.id}: non-indexable route does not explicitly declare noindex")
 
         if machine_rel:
+            parsed_machine = urlparse(machine_rel)
             expected_machine = (
-                urljoin(canonical, machine_rel)
-                if machine_rel.startswith(".")
-                else urljoin(production_base, machine_rel)
+                machine_rel
+                if parsed_machine.scheme
+                else urljoin(navigation_base, machine_rel.lstrip("/"))
             )
-            resolved = {urljoin(canonical, href) for href in page.describedby}
+            resolved = {urljoin(candidate_page, href) for href in page.describedby}
             if expected_machine not in resolved:
-                add_error(errors, f"{route.id}: missing rel=describedby link to {expected_machine}")
+                add_error(errors, f"{route.id}: missing rel=describedby link to candidate machine description {expected_machine}")
 
         for rendered in page.actions:
             action, href, tag = rendered["action"], rendered["href"], rendered["tag"]

--- a/scripts/public-web/validate-surface-contract.py
+++ b/scripts/public-web/validate-surface-contract.py
@@ -1,17 +1,5 @@
 #!/usr/bin/env python3
-"""
-Validate a generated static public surface against a project-owned machine contract.
-
-This validator is intentionally dependency-free and read-only. It covers cheap,
-deterministic checks that do not require browser execution:
-- contract/model structural validity and required-state reachability;
-- rendered link/action classification against the expected graph;
-- project-base-path containment;
-- canonical/title/noindex consistency;
-- sitemap/robots/discovery consistency.
-
-Browser execution of JS-only transitions remains a consumer-owned Playwright concern.
-"""
+"""Read-only deterministic public-surface model/discovery conformance validator."""
 from __future__ import annotations
 
 import argparse
@@ -19,16 +7,16 @@ import json
 import posixpath
 import re
 import sys
+import xml.etree.ElementTree as ET
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin, urlparse, urlunparse
-import xml.etree.ElementTree as ET
 
-
-SCHEMA = "public-surface-contract/1"
+CONTRACT_SCHEMA = "public-surface-contract/1"
+EVIDENCE_SCHEMA = "public-surface-conformance-evidence/1"
 
 
 class ValidationError(Exception):
@@ -46,45 +34,40 @@ class Route:
     lastmod: str | None
 
 
-class SurfaceHTMLParser(HTMLParser):
+class PageParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
-        self.title_parts: list[str] = []
         self._in_title = False
+        self._title: list[str] = []
         self.states: list[str] = []
         self.canonicals: list[str] = []
         self.describedby: list[str] = []
-        self.meta_robots: list[str] = []
+        self.robots: list[str] = []
         self.actions: list[dict[str, str | None]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
         a = {k.lower(): v for k, v in attrs}
-        if tag.lower() == "title":
+        if tag == "title":
             self._in_title = True
-        state = a.get("data-surface-state")
-        if state:
-            self.states.append(state)
-        if tag.lower() == "link":
+        if a.get("data-surface-state"):
+            self.states.append(a["data-surface-state"] or "")
+        if tag == "link":
             rel = set((a.get("rel") or "").lower().split())
-            href = a.get("href")
-            if href and "canonical" in rel:
-                self.canonicals.append(href)
-            if href and "describedby" in rel:
-                self.describedby.append(href)
-        if tag.lower() == "meta" and (a.get("name") or "").lower() in {"robots", "googlebot"}:
+            if a.get("href") and "canonical" in rel:
+                self.canonicals.append(a["href"] or "")
+            if a.get("href") and "describedby" in rel:
+                self.describedby.append(a["href"] or "")
+        if tag == "meta" and (a.get("name") or "").lower() in {"robots", "googlebot"}:
             if a.get("content"):
-                self.meta_robots.append(a["content"] or "")
-        if tag.lower() in {"a", "button"}:
-            action = a.get("data-surface-action")
-            href = a.get("href") if tag.lower() == "a" else None
-            self.actions.append(
-                {
-                    "tag": tag.lower(),
-                    "action": action,
-                    "href": href,
-                    "handoff": a.get("data-surface-handoff"),
-                }
-            )
+                self.robots.append(a["content"] or "")
+        if tag in {"a", "button"}:
+            self.actions.append({
+                "tag": tag,
+                "action": a.get("data-surface-action"),
+                "href": a.get("href") if tag == "a" else None,
+                "handoff": a.get("data-surface-handoff"),
+            })
 
     def handle_endtag(self, tag: str) -> None:
         if tag.lower() == "title":
@@ -92,83 +75,75 @@ class SurfaceHTMLParser(HTMLParser):
 
     def handle_data(self, data: str) -> None:
         if self._in_title:
-            self.title_parts.append(data)
+            self._title.append(data)
 
     @property
     def title(self) -> str:
-        return " ".join("".join(self.title_parts).split())
+        return " ".join("".join(self._title).split())
 
 
-def fail(errors: list[str], message: str) -> None:
+def error(errors: list[str], message: str) -> None:
     errors.append(message)
 
 
-def normalize_route_path(value: str) -> str:
-    if not isinstance(value, str) or not value.startswith("/"):
-        raise ValidationError(f"route path must start with '/': {value!r}")
-    parsed = urlparse(value)
-    if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
-        raise ValidationError(f"route path must be a path only: {value!r}")
-    raw = re.sub(r"/+", "/", parsed.path)
-    norm = posixpath.normpath(raw)
-    if not norm.startswith("/"):
-        norm = "/" + norm
-    if raw.endswith("/") and norm != "/":
-        norm += "/"
-    if ".." in Path(norm).parts:
-        raise ValidationError(f"route path may not contain '..': {value!r}")
-    return norm
-
-
-def normalize_base_url(value: str) -> str:
+def norm_base(value: str, field: str) -> str:
     p = urlparse(value)
-    if p.scheme not in {"http", "https"} or not p.netloc:
-        raise ValidationError("production_base_url must be an absolute http(s) URL")
-    if p.query or p.fragment:
-        raise ValidationError("production_base_url may not contain query/fragment")
+    if p.scheme not in {"http", "https"} or not p.netloc or p.query or p.fragment:
+        raise ValidationError(f"{field} must be an absolute http(s) URL without query/fragment")
     path = p.path or "/"
     if not path.endswith("/"):
         path += "/"
     return urlunparse((p.scheme, p.netloc, path, "", "", ""))
 
 
-def route_url(base_url: str, route_path: str) -> str:
-    rel = route_path.lstrip("/")
-    return urljoin(base_url, rel)
+def norm_route(value: Any) -> str:
+    if not isinstance(value, str) or not value.startswith("/"):
+        raise ValidationError(f"route path must start with '/': {value!r}")
+    p = urlparse(value)
+    if p.scheme or p.netloc or p.query or p.fragment:
+        raise ValidationError(f"route path must be path-only: {value!r}")
+    raw = re.sub(r"/+", "/", p.path)
+    norm = posixpath.normpath(raw)
+    if not norm.startswith("/"):
+        norm = "/" + norm
+    if raw.endswith("/") and norm != "/":
+        norm += "/"
+    return norm
 
 
-def local_file_for_route(site_dir: Path, route_path: str) -> Path:
-    rel = route_path.lstrip("/")
+def project_url(base: str, route_path: str) -> str:
+    return urljoin(base, route_path.lstrip("/"))
+
+
+def route_file(site_dir: Path, path: str) -> Path:
+    rel = path.lstrip("/")
     if not rel:
         return site_dir / "index.html"
-    if route_path.endswith("/"):
+    if path.endswith("/"):
         return site_dir / rel / "index.html"
-    suffix = Path(rel).suffix.lower()
-    if suffix in {".html", ".htm"}:
+    if Path(rel).suffix.lower() in {".html", ".htm"}:
         return site_dir / rel
     return site_dir / rel / "index.html"
 
 
-def parse_html(path: Path) -> SurfaceHTMLParser:
-    parser = SurfaceHTMLParser()
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError(f"{path} must contain a JSON object")
+    return value
+
+
+def parse_page(path: Path) -> PageParser:
+    parser = PageParser()
     parser.feed(path.read_text(encoding="utf-8"))
     parser.close()
     return parser
 
 
-def load_contract(path: Path) -> dict[str, Any]:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValidationError(f"cannot read contract {path}: {exc}") from exc
-    if not isinstance(value, dict):
-        raise ValidationError("contract root must be an object")
-    if value.get("schema") != SCHEMA:
-        raise ValidationError(f"contract schema must be {SCHEMA!r}")
-    return value
-
-
-def build_routes(contract: dict[str, Any]) -> tuple[list[Route], dict[str, Route], dict[str, Route]]:
+def load_routes(contract: dict[str, Any]) -> tuple[list[Route], dict[str, Route], dict[str, Route]]:
     raw_routes = contract.get("routes")
     if not isinstance(raw_routes, list) or not raw_routes:
         raise ValidationError("routes must be a non-empty array")
@@ -177,114 +152,114 @@ def build_routes(contract: dict[str, Any]) -> tuple[list[Route], dict[str, Route
     by_path: dict[str, Route] = {}
     for raw in raw_routes:
         if not isinstance(raw, dict):
-            raise ValidationError("each route must be an object")
-        rid = raw.get("id")
-        title = raw.get("title")
+            raise ValidationError("route entries must be objects")
+        rid, title = raw.get("id"), raw.get("title")
         if not isinstance(rid, str) or not rid:
-            raise ValidationError("each route requires non-empty string id")
+            raise ValidationError("route id must be a non-empty string")
         if not isinstance(title, str) or not title.strip():
-            raise ValidationError(f"route {rid!r} requires a non-empty expected title")
-        path = normalize_route_path(raw.get("path"))
-        if rid in by_id:
-            raise ValidationError(f"duplicate route id: {rid}")
-        if path in by_path:
-            raise ValidationError(f"duplicate route path: {path}")
+            raise ValidationError(f"route {rid!r} requires an exact expected title")
+        path = norm_route(raw.get("path"))
+        if rid in by_id or path in by_path:
+            raise ValidationError(f"duplicate route id/path: {rid!r} {path!r}")
+        lastmod = raw.get("lastmod")
+        if lastmod is not None and not isinstance(lastmod, str):
+            raise ValidationError(f"route {rid!r} lastmod must be a string")
         route = Route(
-            id=rid,
-            path=path,
-            title=title.strip(),
-            indexable=bool(raw.get("indexable", True)),
-            required=bool(raw.get("required", True)),
-            terminal=bool(raw.get("terminal", False)),
-            lastmod=raw.get("lastmod"),
+            rid, path, title.strip(),
+            bool(raw.get("indexable", True)),
+            bool(raw.get("required", True)),
+            bool(raw.get("terminal", False)),
+            lastmod,
         )
-        if route.lastmod is not None and not isinstance(route.lastmod, str):
-            raise ValidationError(f"route {rid!r} lastmod must be a string when present")
         routes.append(route)
         by_id[rid] = route
         by_path[path] = route
     return routes, by_id, by_path
 
 
-def load_actions(contract: dict[str, Any], route_by_id: dict[str, Route]) -> tuple[dict[tuple[str, str], dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
-    edges: dict[tuple[str, str], dict[str, Any]] = {}
-    nav: dict[str, dict[str, Any]] = {}
+def load_action_contract(
+    contract: dict[str, Any], by_id: dict[str, Route]
+) -> tuple[
+    dict[tuple[str, str], dict[str, Any]],
+    dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
+]:
+    transitions: dict[tuple[str, str], dict[str, Any]] = {}
+    navigation: dict[str, dict[str, Any]] = {}
     handoffs: dict[str, dict[str, Any]] = {}
     exceptions: dict[str, dict[str, Any]] = {}
 
-    for edge in contract.get("transitions", []):
-        if not isinstance(edge, dict):
-            raise ValidationError("transition must be object")
-        src, action, target = edge.get("from"), edge.get("action"), edge.get("to")
-        if src not in route_by_id or target not in route_by_id or not isinstance(action, str) or not action:
-            raise ValidationError(f"invalid transition: {edge!r}")
+    for item in contract.get("transitions", []):
+        if not isinstance(item, dict):
+            raise ValidationError("transition entries must be objects")
+        src, action, target = item.get("from"), item.get("action"), item.get("to")
+        if src not in by_id or target not in by_id or not isinstance(action, str) or not action:
+            raise ValidationError(f"invalid transition: {item!r}")
         key = (src, action)
-        if key in edges:
-            raise ValidationError(f"duplicate transition action {action!r} from {src!r}")
-        edges[key] = edge
+        if key in transitions:
+            raise ValidationError(f"duplicate transition: {key!r}")
+        transitions[key] = item
 
     for item in contract.get("navigation", []):
         if not isinstance(item, dict):
-            raise ValidationError("navigation item must be object")
+            raise ValidationError("navigation entries must be objects")
         action, target, cls = item.get("action"), item.get("to"), item.get("class")
-        if not isinstance(action, str) or not action or target not in route_by_id or cls not in {"global", "utility"}:
-            raise ValidationError(f"invalid navigation item: {item!r}")
-        if action in nav:
-            raise ValidationError(f"duplicate navigation action: {action}")
-        nav[action] = item
+        if not isinstance(action, str) or not action or target not in by_id or cls not in {"global", "utility"}:
+            raise ValidationError(f"invalid navigation: {item!r}")
+        if action in navigation:
+            raise ValidationError(f"duplicate navigation action {action!r}")
+        navigation[action] = item
 
     for item in contract.get("handoffs", []):
         if not isinstance(item, dict):
-            raise ValidationError("handoff must be object")
+            raise ValidationError("handoff entries must be objects")
         action = item.get("action")
         if not isinstance(action, str) or not action:
             raise ValidationError(f"invalid handoff action: {item!r}")
         if not any(isinstance(item.get(k), str) and item.get(k) for k in ("url", "url_prefix")):
             raise ValidationError(f"handoff {action!r} requires url or url_prefix")
         if action in handoffs:
-            raise ValidationError(f"duplicate handoff action: {action}")
+            raise ValidationError(f"duplicate handoff action {action!r}")
         handoffs[action] = item
 
     for item in contract.get("exceptions", []):
         if not isinstance(item, dict):
-            raise ValidationError("exception must be object")
-        action = item.get("action")
-        if not isinstance(action, str) or not action or not isinstance(item.get("reason"), str):
+            raise ValidationError("exception entries must be objects")
+        action, reason = item.get("action"), item.get("reason")
+        if not isinstance(action, str) or not action or not isinstance(reason, str) or not reason:
             raise ValidationError(f"invalid exception: {item!r}")
         if action in exceptions:
-            raise ValidationError(f"duplicate exception action: {action}")
+            raise ValidationError(f"duplicate exception action {action!r}")
         exceptions[action] = item
 
-    namespaces = defaultdict(list)
-    for label, mapping in [("navigation", nav), ("handoff", handoffs), ("exception", exceptions)]:
+    seen: dict[str, str] = {}
+    for kind, mapping in [("navigation", navigation), ("handoff", handoffs), ("exception", exceptions)]:
         for action in mapping:
-            namespaces[action].append(label)
-    for action, kinds in namespaces.items():
-        if len(kinds) > 1:
-            raise ValidationError(f"action {action!r} is ambiguously declared in {kinds}")
-    return edges, nav, handoffs, exceptions
+            if action in seen:
+                raise ValidationError(f"action {action!r} appears in both {seen[action]} and {kind}")
+            seen[action] = kind
+    return transitions, navigation, handoffs, exceptions
 
 
-def check_reachability(
+def check_model(
     contract: dict[str, Any],
     routes: list[Route],
-    route_by_id: dict[str, Route],
-    edges: dict[tuple[str, str], dict[str, Any]],
-    nav: dict[str, dict[str, Any]],
+    by_id: dict[str, Route],
+    transitions: dict[tuple[str, str], dict[str, Any]],
+    navigation: dict[str, dict[str, Any]],
     errors: list[str],
 ) -> None:
     entries = contract.get("entry_states")
-    if not isinstance(entries, list) or not entries or any(e not in route_by_id for e in entries):
-        fail(errors, "entry_states must be a non-empty array of declared route ids")
+    if not isinstance(entries, list) or not entries or any(e not in by_id for e in entries):
+        error(errors, "entry_states must be a non-empty list of declared route ids")
         return
-
     graph: dict[str, set[str]] = defaultdict(set)
-    for (src, _), edge in edges.items():
-        graph[src].add(edge["to"])
-    for src in route_by_id:
-        for item in nav.values():
+    for (src, _), item in transitions.items():
+        graph[src].add(item["to"])
+    for src in by_id:
+        for item in navigation.values():
             graph[src].add(item["to"])
-
     seen: set[str] = set()
     queue = deque(entries)
     while queue:
@@ -295,14 +270,7 @@ def check_reachability(
         queue.extend(sorted(graph[current] - seen))
     for route in routes:
         if route.required and route.id not in seen:
-            fail(errors, f"required route/state {route.id!r} is unreachable from entry_states")
-
-    outgoing = defaultdict(int)
-    for (src, _), edge in edges.items():
-        outgoing[src] += 1
-    for route in routes:
-        if route.required and not route.terminal and outgoing[route.id] == 0 and not nav:
-            fail(errors, f"required non-terminal route/state {route.id!r} has no declared continuation/recovery path")
+            error(errors, f"required route/state {route.id!r} is unreachable from entry_states")
 
 
 def parse_sitemap(path: Path) -> dict[str, str | None]:
@@ -313,266 +281,291 @@ def parse_sitemap(path: Path) -> dict[str, str | None]:
     except (OSError, ET.ParseError) as exc:
         raise ValidationError(f"invalid sitemap {path}: {exc}") from exc
     result: dict[str, str | None] = {}
-    for url in root.findall(".//{*}url"):
-        loc_el = url.find("{*}loc")
-        lastmod_el = url.find("{*}lastmod")
-        if loc_el is None or not (loc_el.text or "").strip():
-            raise ValidationError("sitemap url entry missing loc")
-        loc = (loc_el.text or "").strip()
+    for node in root.findall(".//{*}url"):
+        loc_node, last_node = node.find("{*}loc"), node.find("{*}lastmod")
+        loc = (loc_node.text or "").strip() if loc_node is not None else ""
+        if not loc:
+            raise ValidationError("sitemap URL entry is missing loc")
         if loc in result:
-            raise ValidationError(f"duplicate sitemap URL: {loc}")
-        result[loc] = (lastmod_el.text or "").strip() if lastmod_el is not None and (lastmod_el.text or "").strip() else None
+            raise ValidationError(f"duplicate sitemap URL {loc!r}")
+        result[loc] = (last_node.text or "").strip() if last_node is not None and (last_node.text or "").strip() else None
     return result
 
 
-def parse_robots(path: Path) -> tuple[list[str], list[tuple[str, str]]]:
+def parse_robots(path: Path) -> tuple[list[str], list[tuple[str, str, str]]]:
     if not path.exists():
         raise ValidationError(f"missing robots.txt: {path}")
     sitemaps: list[str] = []
-    directives: list[tuple[str, str]] = []
-    current_agents: list[str] = []
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.split("#", 1)[0].strip()
+    directives: list[tuple[str, str, str]] = []
+    agents: list[str] = []
+    previous_was_agent = False
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
         if not line or ":" not in line:
+            previous_was_agent = False if not line else previous_was_agent
             continue
-        key, value = [x.strip() for x in line.split(":", 1)]
-        key_l = key.lower()
-        if key_l == "user-agent":
-            current_agents = [value.lower()]
-        elif key_l == "sitemap":
+        key, value = [v.strip() for v in line.split(":", 1)]
+        key = key.lower()
+        if key == "user-agent":
+            if not previous_was_agent:
+                agents = []
+            agents.append(value.lower())
+            previous_was_agent = True
+        elif key == "sitemap":
             sitemaps.append(value)
-        elif key_l in {"allow", "disallow"}:
-            for agent in current_agents or ["*"]:
-                directives.append((agent, f"{key_l}:{value}"))
+            previous_was_agent = False
+        elif key in {"allow", "disallow"}:
+            for agent in agents or ["*"]:
+                directives.append((agent, key, value))
+            previous_was_agent = False
+        else:
+            previous_was_agent = False
     return sitemaps, directives
 
 
-def is_same_site(url: str, base_url: str) -> tuple[bool, bool]:
-    u, b = urlparse(url), urlparse(base_url)
+def same_origin_and_base(url: str, base: str) -> tuple[bool, bool]:
+    u, b = urlparse(url), urlparse(base)
     same_origin = (u.scheme, u.netloc) == (b.scheme, b.netloc)
     base_path = b.path if b.path.endswith("/") else b.path + "/"
-    in_base = same_origin and (u.path == base_path[:-1] or u.path.startswith(base_path))
-    return same_origin, in_base
+    return same_origin, same_origin and (u.path == base_path[:-1] or u.path.startswith(base_path))
 
 
-def route_id_for_absolute(url: str, base_url: str, route_by_path: dict[str, Route]) -> str | None:
-    p = urlparse(url)
-    b = urlparse(base_url)
+def target_route(url: str, navigation_base: str, by_path: dict[str, Route]) -> str | None:
+    u, b = urlparse(url), urlparse(navigation_base)
     base_path = b.path if b.path.endswith("/") else b.path + "/"
-    if not p.path.startswith(base_path):
+    if not (u.path == base_path[:-1] or u.path.startswith(base_path)):
         return None
-    rel = p.path[len(base_path):]
-    project_path = "/" + rel
-    if project_path == "/":
-        project_path = "/"
-    elif p.path.endswith("/") and not project_path.endswith("/"):
-        project_path += "/"
-    try:
-        project_path = normalize_route_path(project_path)
-    except ValidationError:
-        return None
-    route = route_by_path.get(project_path)
+    rel = "" if u.path == base_path[:-1] else u.path[len(base_path):]
+    path = norm_route("/" + rel)
+    route = by_path.get(path)
     return route.id if route else None
 
 
-def validate(contract_path: Path, site_dir: Path) -> dict[str, Any]:
+def required_sources(item: dict[str, Any], routes: list[Route]) -> set[str]:
+    raw = item.get("required_on")
+    if raw is None:
+        return {route.id for route in routes if route.required}
+    if raw is False:
+        return set()
+    if not isinstance(raw, list) or any(not isinstance(v, str) for v in raw):
+        raise ValidationError("navigation required_on must be false or a list of route ids")
+    return set(raw)
+
+
+def validate(
+    contract_path: Path, site_dir: Path, navigation_base_url: str | None = None
+) -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
-    contract = load_contract(contract_path)
-    base_url = normalize_base_url(contract.get("production_base_url", ""))
-    routes, route_by_id, route_by_path = build_routes(contract)
-    edges, nav, handoffs, exceptions = load_actions(contract, route_by_id)
-    check_reachability(contract, routes, route_by_id, edges, nav, errors)
+    contract = read_json(contract_path)
+    if contract.get("schema") != CONTRACT_SCHEMA:
+        raise ValidationError(f"contract schema must be {CONTRACT_SCHEMA!r}")
 
-    observed_edges: list[dict[str, Any]] = []
-    observed_handoffs: list[dict[str, Any]] = []
-    browser_required: list[dict[str, Any]] = []
-    seen_required_edges: set[tuple[str, str]] = set()
+    production_base = norm_base(contract.get("production_base_url", ""), "production_base_url")
+    navigation_base = norm_base(
+        navigation_base_url or production_base, "navigation_base_url"
+    )
+    routes, by_id, by_path = load_routes(contract)
+    transitions, navigation, handoffs, exceptions = load_action_contract(contract, by_id)
+    check_model(contract, routes, by_id, transitions, navigation, errors)
 
     discovery = contract.get("discovery") or {}
     if not isinstance(discovery, dict):
         raise ValidationError("discovery must be an object")
     sitemap_rel = discovery.get("sitemap", "sitemap.xml")
     robots_rel = discovery.get("robots", "robots.txt")
-    describedby_rel = discovery.get("machine_description")
-    sitemap_url = urljoin(base_url, sitemap_rel)
+    machine_rel = discovery.get("machine_description")
 
-    expected_sitemap: dict[str, str | None] = {}
-    for route in routes:
-        if route.indexable:
-            expected_sitemap[route_url(base_url, route.path)] = route.lastmod
-
+    expected_sitemap = {
+        project_url(production_base, route.path): route.lastmod
+        for route in routes if route.indexable
+    }
     actual_sitemap = parse_sitemap(site_dir / sitemap_rel)
-    if set(actual_sitemap) != set(expected_sitemap):
-        missing = sorted(set(expected_sitemap) - set(actual_sitemap))
-        unexpected = sorted(set(actual_sitemap) - set(expected_sitemap))
-        if missing:
-            fail(errors, f"sitemap missing indexable canonical routes: {missing}")
-        if unexpected:
-            fail(errors, f"sitemap contains undeclared/non-indexable routes: {unexpected}")
-    for loc in sorted(set(actual_sitemap) & set(expected_sitemap)):
-        expected_lastmod = expected_sitemap[loc]
-        actual_lastmod = actual_sitemap[loc]
-        if expected_lastmod != actual_lastmod:
-            fail(errors, f"sitemap lastmod mismatch for {loc}: expected {expected_lastmod!r}, got {actual_lastmod!r}")
+    missing = sorted(set(expected_sitemap) - set(actual_sitemap))
+    unexpected = sorted(set(actual_sitemap) - set(expected_sitemap))
+    if missing:
+        error(errors, f"sitemap missing indexable canonical routes: {missing}")
+    if unexpected:
+        error(errors, f"sitemap contains undeclared/non-indexable routes: {unexpected}")
+    for loc in sorted(set(expected_sitemap) & set(actual_sitemap)):
+        if expected_sitemap[loc] != actual_sitemap[loc]:
+            error(errors, f"sitemap lastmod mismatch for {loc}: expected {expected_sitemap[loc]!r}, got {actual_sitemap[loc]!r}")
 
+    sitemap_url = urljoin(production_base, sitemap_rel)
     robot_sitemaps, robot_directives = parse_robots(site_dir / robots_rel)
     if sitemap_url not in robot_sitemaps:
-        fail(errors, f"robots.txt must advertise canonical sitemap URL {sitemap_url}")
-    base_path = urlparse(base_url).path
-    for agent, directive in robot_directives:
-        if agent == "*" and directive.lower().startswith("disallow:"):
-            disallow = directive.split(":", 1)[1].strip()
-            if disallow in {"/", base_path, base_path.rstrip("/")}:
-                fail(errors, f"robots.txt blocks the production site for User-agent *: {directive}")
+        error(errors, f"robots.txt must advertise canonical sitemap URL {sitemap_url}")
+    production_path = urlparse(production_base).path
+    for agent, kind, value in robot_directives:
+        if agent == "*" and kind == "disallow" and value in {"/", production_path, production_path.rstrip("/")}:
+            error(errors, f"robots.txt blocks production site for User-agent *: Disallow: {value}")
+
+    observed_edges: list[dict[str, str]] = []
+    observed_handoffs: list[dict[str, str]] = []
+    browser_required: list[dict[str, str]] = []
+    seen_transitions: set[tuple[str, str]] = set()
+    seen_navigation: set[tuple[str, str]] = set()
+    internal_outgoing: dict[str, int] = defaultdict(int)
 
     for route in routes:
-        file_path = local_file_for_route(site_dir, route.path)
-        if not file_path.exists():
+        page_path = route_file(site_dir, route.path)
+        if not page_path.exists():
             if route.required:
-                fail(errors, f"missing required rendered route {route.id!r}: {file_path}")
+                error(errors, f"missing required rendered route {route.id!r}: {page_path}")
             continue
-        parser = parse_html(file_path)
-        if parser.states != [route.id]:
-            fail(errors, f"{route.id}: expected exactly data-surface-state={route.id!r}, observed {parser.states!r}")
-        if parser.title != route.title:
-            fail(errors, f"{route.id}: title mismatch: expected {route.title!r}, got {parser.title!r}")
+        page = parse_page(page_path)
+        canonical = project_url(production_base, route.path)
+        candidate_page = project_url(navigation_base, route.path)
 
-        canonical = route_url(base_url, route.path)
-        if parser.canonicals != [canonical]:
-            fail(errors, f"{route.id}: expected exactly canonical {canonical!r}, observed {parser.canonicals!r}")
-        noindex = any("noindex" in {t.strip().lower() for t in content.split(",")} for content in parser.meta_robots)
+        if page.states != [route.id]:
+            error(errors, f"{route.id}: expected exactly data-surface-state={route.id!r}, observed {page.states!r}")
+        if page.title != route.title:
+            error(errors, f"{route.id}: title mismatch: expected {route.title!r}, got {page.title!r}")
+        if page.canonicals != [canonical]:
+            error(errors, f"{route.id}: expected exactly canonical {canonical!r}, observed {page.canonicals!r}")
+        noindex = any(
+            "noindex" in {token.strip().lower() for token in value.split(",")}
+            for value in page.robots
+        )
         if route.indexable and noindex:
-            fail(errors, f"{route.id}: indexable route is marked noindex")
+            error(errors, f"{route.id}: indexable route is marked noindex")
         if not route.indexable and not noindex:
-            warnings.append(f"{route.id}: route is non-indexable by contract but page does not explicitly declare noindex")
+            warnings.append(f"{route.id}: non-indexable route does not explicitly declare noindex")
 
-        if describedby_rel:
-            describedby_abs = urljoin(base_url, describedby_rel)
-            resolved = {urljoin(canonical, href) for href in parser.describedby}
-            if describedby_abs not in resolved:
-                fail(errors, f"{route.id}: missing rel=describedby discovery link to {describedby_abs}")
+        if machine_rel:
+            expected_machine = urljoin(canonical, machine_rel) if machine_rel.startswith(".") else urljoin(production_base, machine_rel)
+            resolved = {urljoin(canonical, href) for href in page.describedby}
+            if expected_machine not in resolved:
+                error(errors, f"{route.id}: missing rel=describedby link to {expected_machine}")
 
-        for item in parser.actions:
-            action = item["action"]
-            href = item["href"]
-            tag = item["tag"]
+        for rendered in page.actions:
+            action, href, tag = rendered["action"], rendered["href"], rendered["tag"]
             if not action:
-                if tag == "a" and href:
-                    fail(errors, f"{route.id}: rendered link {href!r} lacks data-surface-action classification")
-                elif tag == "button":
-                    fail(errors, f"{route.id}: rendered button lacks data-surface-action classification")
+                if (tag == "a" and href) or tag == "button":
+                    error(errors, f"{route.id}: rendered {tag} lacks data-surface-action classification")
                 continue
 
-            edge = edges.get((route.id, action))
-            nav_item = nav.get(action)
+            transition = transitions.get((route.id, action))
+            nav = navigation.get(action)
             handoff = handoffs.get(action)
             exception = exceptions.get(action)
-            matched = sum(x is not None for x in (edge, nav_item, handoff, exception))
-            if matched == 0:
-                fail(errors, f"{route.id}: rendered action {action!r} is undeclared")
-                continue
-            if matched > 1:
-                fail(errors, f"{route.id}: rendered action {action!r} matches multiple classifications")
+            matches = sum(v is not None for v in (transition, nav, handoff, exception))
+            if matches != 1:
+                error(errors, f"{route.id}: rendered action {action!r} has {matches} declared classifications")
                 continue
             if exception:
                 continue
 
             if href is None:
-                if edge and bool(edge.get("browser_required", False)):
-                    browser_required.append({"from": route.id, "action": action, "to": edge["to"]})
-                    seen_required_edges.add((route.id, action))
-                elif nav_item and bool(nav_item.get("browser_required", False)):
-                    browser_required.append({"from": route.id, "action": action, "to": nav_item["to"]})
+                declared = transition or nav
+                if declared and bool(declared.get("browser_required", False)):
+                    target = declared["to"]
+                    browser_required.append({"from": route.id, "action": action, "to": target})
+                    internal_outgoing[route.id] += 1
+                    if transition:
+                        seen_transitions.add((route.id, action))
+                    if nav:
+                        seen_navigation.add((route.id, action))
                 else:
-                    fail(errors, f"{route.id}: action {action!r} has no href and is not declared browser_required")
+                    error(errors, f"{route.id}: action {action!r} has no href and is not browser_required")
                 continue
 
-            absolute = urljoin(canonical, href)
-            same_origin, in_base = is_same_site(absolute, base_url)
+            absolute = urljoin(candidate_page, href)
+            same_origin, in_base = same_origin_and_base(absolute, navigation_base)
 
-            if edge or nav_item:
-                target_id = edge["to"] if edge else nav_item["to"]
+            if transition or nav:
+                target = (transition or nav)["to"]
                 if same_origin and not in_base:
-                    fail(errors, f"{route.id}: internal action {action!r} escapes project base path: {absolute}")
+                    error(errors, f"{route.id}: internal action {action!r} escapes candidate project base path: {absolute}")
                     continue
                 if not same_origin:
-                    fail(errors, f"{route.id}: internal action {action!r} unexpectedly exits site: {absolute}")
+                    error(errors, f"{route.id}: internal action {action!r} unexpectedly exits candidate site: {absolute}")
                     continue
-                observed_target = route_id_for_absolute(absolute, base_url, route_by_path)
-                if observed_target != target_id:
-                    fail(errors, f"{route.id}: action {action!r} targets {observed_target!r}/{absolute}, expected {target_id!r}")
+                observed_target = target_route(absolute, navigation_base, by_path)
+                if observed_target != target:
+                    error(errors, f"{route.id}: action {action!r} targets {observed_target!r}/{absolute}, expected {target!r}")
                     continue
-                observed_edges.append({"from": route.id, "action": action, "to": target_id, "class": "flow" if edge else nav_item["class"]})
-                if edge:
-                    seen_required_edges.add((route.id, action))
+                cls = "flow" if transition else nav["class"]
+                observed_edges.append({"from": route.id, "action": action, "to": target, "class": cls})
+                internal_outgoing[route.id] += 1
+                if transition:
+                    seen_transitions.add((route.id, action))
+                if nav:
+                    seen_navigation.add((route.id, action))
                 continue
 
             if handoff:
                 if same_origin:
-                    fail(errors, f"{route.id}: external handoff {action!r} unexpectedly stays on same origin: {absolute}")
+                    error(errors, f"{route.id}: external handoff {action!r} unexpectedly stays on candidate origin: {absolute}")
                     continue
-                exact = handoff.get("url")
-                prefix = handoff.get("url_prefix")
+                exact, prefix = handoff.get("url"), handoff.get("url_prefix")
                 if exact and absolute != exact:
-                    fail(errors, f"{route.id}: handoff {action!r} URL mismatch: {absolute!r} != {exact!r}")
+                    error(errors, f"{route.id}: handoff {action!r} URL mismatch: {absolute!r} != {exact!r}")
                     continue
                 if prefix and not absolute.startswith(prefix):
-                    fail(errors, f"{route.id}: handoff {action!r} URL {absolute!r} does not match prefix {prefix!r}")
+                    error(errors, f"{route.id}: handoff {action!r} URL {absolute!r} does not match prefix {prefix!r}")
                     continue
-                declared_handoff = handoff.get("handoff")
-                observed_handoff = item.get("handoff")
-                if declared_handoff and observed_handoff != declared_handoff:
-                    fail(errors, f"{route.id}: handoff {action!r} requires data-surface-handoff={declared_handoff!r}, got {observed_handoff!r}")
+                if handoff.get("handoff") and rendered.get("handoff") != handoff["handoff"]:
+                    error(errors, f"{route.id}: handoff {action!r} requires data-surface-handoff={handoff['handoff']!r}")
                     continue
                 observed_handoffs.append({"from": route.id, "action": action, "url": absolute})
 
-    for key, edge in edges.items():
-        if bool(edge.get("required_rendered", True)) and key not in seen_required_edges:
-            fail(errors, f"required rendered transition missing: {key[0]} --{key[1]}--> {edge['to']}")
+    for key, item in transitions.items():
+        if bool(item.get("required_rendered", True)) and key not in seen_transitions:
+            error(errors, f"required rendered transition missing: {key[0]} --{key[1]}--> {item['to']}")
 
-    evidence = {
-        "schema": "public-surface-conformance-evidence/1",
-        "contract_schema": SCHEMA,
-        "production_base_url": base_url,
+    for action, item in navigation.items():
+        for source in required_sources(item, routes):
+            if source not in by_id:
+                raise ValidationError(f"navigation {action!r} required_on references unknown route {source!r}")
+            if (source, action) not in seen_navigation:
+                error(errors, f"required rendered {item['class']} navigation missing on {source!r}: {action!r}")
+
+    for route in routes:
+        if route.required and not route.terminal and internal_outgoing[route.id] == 0:
+            error(errors, f"required non-terminal route/state {route.id!r} is a rendered dead end")
+
+    return {
+        "schema": EVIDENCE_SCHEMA,
+        "contract_schema": CONTRACT_SCHEMA,
+        "production_base_url": production_base,
+        "navigation_base_url": navigation_base,
         "route_count": len(routes),
-        "expected_transition_count": len(edges),
+        "expected_transition_count": len(transitions),
         "observed_edge_count": len(observed_edges),
         "observed_handoff_count": len(observed_handoffs),
-        "browser_required_actions": sorted(browser_required, key=lambda x: (x["from"], x["action"], x["to"])),
-        "observed_edges": sorted(observed_edges, key=lambda x: (x["from"], x["action"], x["to"])),
-        "external_handoffs": sorted(observed_handoffs, key=lambda x: (x["from"], x["action"], x["url"])),
+        "browser_required_actions": sorted(browser_required, key=lambda v: (v["from"], v["action"], v["to"])),
+        "observed_edges": sorted(observed_edges, key=lambda v: (v["from"], v["action"], v["to"])),
+        "external_handoffs": sorted(observed_handoffs, key=lambda v: (v["from"], v["action"], v["url"])),
         "sitemap_routes": sorted(actual_sitemap),
         "warnings": sorted(warnings),
         "errors": sorted(errors),
         "verdict": "pass" if not errors else "fail",
     }
-    return evidence
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--contract", required=True, type=Path)
     parser.add_argument("--site-dir", required=True, type=Path)
+    parser.add_argument("--navigation-base")
     parser.add_argument("--evidence", type=Path)
     args = parser.parse_args()
-
     try:
-        evidence = validate(args.contract, args.site_dir)
+        evidence = validate(args.contract, args.site_dir, args.navigation_base)
     except ValidationError as exc:
         evidence = {
-            "schema": "public-surface-conformance-evidence/1",
-            "contract_schema": SCHEMA,
+            "schema": EVIDENCE_SCHEMA,
+            "contract_schema": CONTRACT_SCHEMA,
             "verdict": "fail",
             "errors": [str(exc)],
             "warnings": [],
         }
-
-    encoded = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
     if args.evidence:
         args.evidence.parent.mkdir(parents=True, exist_ok=True)
-        args.evidence.write_text(encoded, encoding="utf-8")
-    sys.stdout.write(encoded)
+        args.evidence.write_text(text, encoding="utf-8")
+    sys.stdout.write(text)
     return 0 if evidence["verdict"] == "pass" else 1
 
 

--- a/scripts/public-web/validate-surface-contract.py
+++ b/scripts/public-web/validate-surface-contract.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""
+Validate a generated static public surface against a project-owned machine contract.
+
+This validator is intentionally dependency-free and read-only. It covers cheap,
+deterministic checks that do not require browser execution:
+- contract/model structural validity and required-state reachability;
+- rendered link/action classification against the expected graph;
+- project-base-path containment;
+- canonical/title/noindex consistency;
+- sitemap/robots/discovery consistency.
+
+Browser execution of JS-only transitions remains a consumer-owned Playwright concern.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import re
+import sys
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse, urlunparse
+import xml.etree.ElementTree as ET
+
+
+SCHEMA = "public-surface-contract/1"
+
+
+class ValidationError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class Route:
+    id: str
+    path: str
+    title: str
+    indexable: bool
+    required: bool
+    terminal: bool
+    lastmod: str | None
+
+
+class SurfaceHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.title_parts: list[str] = []
+        self._in_title = False
+        self.states: list[str] = []
+        self.canonicals: list[str] = []
+        self.describedby: list[str] = []
+        self.meta_robots: list[str] = []
+        self.actions: list[dict[str, str | None]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        a = {k.lower(): v for k, v in attrs}
+        if tag.lower() == "title":
+            self._in_title = True
+        state = a.get("data-surface-state")
+        if state:
+            self.states.append(state)
+        if tag.lower() == "link":
+            rel = set((a.get("rel") or "").lower().split())
+            href = a.get("href")
+            if href and "canonical" in rel:
+                self.canonicals.append(href)
+            if href and "describedby" in rel:
+                self.describedby.append(href)
+        if tag.lower() == "meta" and (a.get("name") or "").lower() in {"robots", "googlebot"}:
+            if a.get("content"):
+                self.meta_robots.append(a["content"] or "")
+        if tag.lower() in {"a", "button"}:
+            action = a.get("data-surface-action")
+            href = a.get("href") if tag.lower() == "a" else None
+            self.actions.append(
+                {
+                    "tag": tag.lower(),
+                    "action": action,
+                    "href": href,
+                    "handoff": a.get("data-surface-handoff"),
+                }
+            )
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title_parts.append(data)
+
+    @property
+    def title(self) -> str:
+        return " ".join("".join(self.title_parts).split())
+
+
+def fail(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def normalize_route_path(value: str) -> str:
+    if not isinstance(value, str) or not value.startswith("/"):
+        raise ValidationError(f"route path must start with '/': {value!r}")
+    parsed = urlparse(value)
+    if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
+        raise ValidationError(f"route path must be a path only: {value!r}")
+    raw = re.sub(r"/+", "/", parsed.path)
+    norm = posixpath.normpath(raw)
+    if not norm.startswith("/"):
+        norm = "/" + norm
+    if raw.endswith("/") and norm != "/":
+        norm += "/"
+    if ".." in Path(norm).parts:
+        raise ValidationError(f"route path may not contain '..': {value!r}")
+    return norm
+
+
+def normalize_base_url(value: str) -> str:
+    p = urlparse(value)
+    if p.scheme not in {"http", "https"} or not p.netloc:
+        raise ValidationError("production_base_url must be an absolute http(s) URL")
+    if p.query or p.fragment:
+        raise ValidationError("production_base_url may not contain query/fragment")
+    path = p.path or "/"
+    if not path.endswith("/"):
+        path += "/"
+    return urlunparse((p.scheme, p.netloc, path, "", "", ""))
+
+
+def route_url(base_url: str, route_path: str) -> str:
+    rel = route_path.lstrip("/")
+    return urljoin(base_url, rel)
+
+
+def local_file_for_route(site_dir: Path, route_path: str) -> Path:
+    rel = route_path.lstrip("/")
+    if not rel:
+        return site_dir / "index.html"
+    if route_path.endswith("/"):
+        return site_dir / rel / "index.html"
+    suffix = Path(rel).suffix.lower()
+    if suffix in {".html", ".htm"}:
+        return site_dir / rel
+    return site_dir / rel / "index.html"
+
+
+def parse_html(path: Path) -> SurfaceHTMLParser:
+    parser = SurfaceHTMLParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    parser.close()
+    return parser
+
+
+def load_contract(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot read contract {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValidationError("contract root must be an object")
+    if value.get("schema") != SCHEMA:
+        raise ValidationError(f"contract schema must be {SCHEMA!r}")
+    return value
+
+
+def build_routes(contract: dict[str, Any]) -> tuple[list[Route], dict[str, Route], dict[str, Route]]:
+    raw_routes = contract.get("routes")
+    if not isinstance(raw_routes, list) or not raw_routes:
+        raise ValidationError("routes must be a non-empty array")
+    routes: list[Route] = []
+    by_id: dict[str, Route] = {}
+    by_path: dict[str, Route] = {}
+    for raw in raw_routes:
+        if not isinstance(raw, dict):
+            raise ValidationError("each route must be an object")
+        rid = raw.get("id")
+        title = raw.get("title")
+        if not isinstance(rid, str) or not rid:
+            raise ValidationError("each route requires non-empty string id")
+        if not isinstance(title, str) or not title.strip():
+            raise ValidationError(f"route {rid!r} requires a non-empty expected title")
+        path = normalize_route_path(raw.get("path"))
+        if rid in by_id:
+            raise ValidationError(f"duplicate route id: {rid}")
+        if path in by_path:
+            raise ValidationError(f"duplicate route path: {path}")
+        route = Route(
+            id=rid,
+            path=path,
+            title=title.strip(),
+            indexable=bool(raw.get("indexable", True)),
+            required=bool(raw.get("required", True)),
+            terminal=bool(raw.get("terminal", False)),
+            lastmod=raw.get("lastmod"),
+        )
+        if route.lastmod is not None and not isinstance(route.lastmod, str):
+            raise ValidationError(f"route {rid!r} lastmod must be a string when present")
+        routes.append(route)
+        by_id[rid] = route
+        by_path[path] = route
+    return routes, by_id, by_path
+
+
+def load_actions(contract: dict[str, Any], route_by_id: dict[str, Route]) -> tuple[dict[tuple[str, str], dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    edges: dict[tuple[str, str], dict[str, Any]] = {}
+    nav: dict[str, dict[str, Any]] = {}
+    handoffs: dict[str, dict[str, Any]] = {}
+    exceptions: dict[str, dict[str, Any]] = {}
+
+    for edge in contract.get("transitions", []):
+        if not isinstance(edge, dict):
+            raise ValidationError("transition must be object")
+        src, action, target = edge.get("from"), edge.get("action"), edge.get("to")
+        if src not in route_by_id or target not in route_by_id or not isinstance(action, str) or not action:
+            raise ValidationError(f"invalid transition: {edge!r}")
+        key = (src, action)
+        if key in edges:
+            raise ValidationError(f"duplicate transition action {action!r} from {src!r}")
+        edges[key] = edge
+
+    for item in contract.get("navigation", []):
+        if not isinstance(item, dict):
+            raise ValidationError("navigation item must be object")
+        action, target, cls = item.get("action"), item.get("to"), item.get("class")
+        if not isinstance(action, str) or not action or target not in route_by_id or cls not in {"global", "utility"}:
+            raise ValidationError(f"invalid navigation item: {item!r}")
+        if action in nav:
+            raise ValidationError(f"duplicate navigation action: {action}")
+        nav[action] = item
+
+    for item in contract.get("handoffs", []):
+        if not isinstance(item, dict):
+            raise ValidationError("handoff must be object")
+        action = item.get("action")
+        if not isinstance(action, str) or not action:
+            raise ValidationError(f"invalid handoff action: {item!r}")
+        if not any(isinstance(item.get(k), str) and item.get(k) for k in ("url", "url_prefix")):
+            raise ValidationError(f"handoff {action!r} requires url or url_prefix")
+        if action in handoffs:
+            raise ValidationError(f"duplicate handoff action: {action}")
+        handoffs[action] = item
+
+    for item in contract.get("exceptions", []):
+        if not isinstance(item, dict):
+            raise ValidationError("exception must be object")
+        action = item.get("action")
+        if not isinstance(action, str) or not action or not isinstance(item.get("reason"), str):
+            raise ValidationError(f"invalid exception: {item!r}")
+        if action in exceptions:
+            raise ValidationError(f"duplicate exception action: {action}")
+        exceptions[action] = item
+
+    namespaces = defaultdict(list)
+    for label, mapping in [("navigation", nav), ("handoff", handoffs), ("exception", exceptions)]:
+        for action in mapping:
+            namespaces[action].append(label)
+    for action, kinds in namespaces.items():
+        if len(kinds) > 1:
+            raise ValidationError(f"action {action!r} is ambiguously declared in {kinds}")
+    return edges, nav, handoffs, exceptions
+
+
+def check_reachability(
+    contract: dict[str, Any],
+    routes: list[Route],
+    route_by_id: dict[str, Route],
+    edges: dict[tuple[str, str], dict[str, Any]],
+    nav: dict[str, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    entries = contract.get("entry_states")
+    if not isinstance(entries, list) or not entries or any(e not in route_by_id for e in entries):
+        fail(errors, "entry_states must be a non-empty array of declared route ids")
+        return
+
+    graph: dict[str, set[str]] = defaultdict(set)
+    for (src, _), edge in edges.items():
+        graph[src].add(edge["to"])
+    for src in route_by_id:
+        for item in nav.values():
+            graph[src].add(item["to"])
+
+    seen: set[str] = set()
+    queue = deque(entries)
+    while queue:
+        current = queue.popleft()
+        if current in seen:
+            continue
+        seen.add(current)
+        queue.extend(sorted(graph[current] - seen))
+    for route in routes:
+        if route.required and route.id not in seen:
+            fail(errors, f"required route/state {route.id!r} is unreachable from entry_states")
+
+    outgoing = defaultdict(int)
+    for (src, _), edge in edges.items():
+        outgoing[src] += 1
+    for route in routes:
+        if route.required and not route.terminal and outgoing[route.id] == 0 and not nav:
+            fail(errors, f"required non-terminal route/state {route.id!r} has no declared continuation/recovery path")
+
+
+def parse_sitemap(path: Path) -> dict[str, str | None]:
+    if not path.exists():
+        raise ValidationError(f"missing sitemap: {path}")
+    try:
+        root = ET.fromstring(path.read_text(encoding="utf-8"))
+    except (OSError, ET.ParseError) as exc:
+        raise ValidationError(f"invalid sitemap {path}: {exc}") from exc
+    result: dict[str, str | None] = {}
+    for url in root.findall(".//{*}url"):
+        loc_el = url.find("{*}loc")
+        lastmod_el = url.find("{*}lastmod")
+        if loc_el is None or not (loc_el.text or "").strip():
+            raise ValidationError("sitemap url entry missing loc")
+        loc = (loc_el.text or "").strip()
+        if loc in result:
+            raise ValidationError(f"duplicate sitemap URL: {loc}")
+        result[loc] = (lastmod_el.text or "").strip() if lastmod_el is not None and (lastmod_el.text or "").strip() else None
+    return result
+
+
+def parse_robots(path: Path) -> tuple[list[str], list[tuple[str, str]]]:
+    if not path.exists():
+        raise ValidationError(f"missing robots.txt: {path}")
+    sitemaps: list[str] = []
+    directives: list[tuple[str, str]] = []
+    current_agents: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line or ":" not in line:
+            continue
+        key, value = [x.strip() for x in line.split(":", 1)]
+        key_l = key.lower()
+        if key_l == "user-agent":
+            current_agents = [value.lower()]
+        elif key_l == "sitemap":
+            sitemaps.append(value)
+        elif key_l in {"allow", "disallow"}:
+            for agent in current_agents or ["*"]:
+                directives.append((agent, f"{key_l}:{value}"))
+    return sitemaps, directives
+
+
+def is_same_site(url: str, base_url: str) -> tuple[bool, bool]:
+    u, b = urlparse(url), urlparse(base_url)
+    same_origin = (u.scheme, u.netloc) == (b.scheme, b.netloc)
+    base_path = b.path if b.path.endswith("/") else b.path + "/"
+    in_base = same_origin and (u.path == base_path[:-1] or u.path.startswith(base_path))
+    return same_origin, in_base
+
+
+def route_id_for_absolute(url: str, base_url: str, route_by_path: dict[str, Route]) -> str | None:
+    p = urlparse(url)
+    b = urlparse(base_url)
+    base_path = b.path if b.path.endswith("/") else b.path + "/"
+    if not p.path.startswith(base_path):
+        return None
+    rel = p.path[len(base_path):]
+    project_path = "/" + rel
+    if project_path == "/":
+        project_path = "/"
+    elif p.path.endswith("/") and not project_path.endswith("/"):
+        project_path += "/"
+    try:
+        project_path = normalize_route_path(project_path)
+    except ValidationError:
+        return None
+    route = route_by_path.get(project_path)
+    return route.id if route else None
+
+
+def validate(contract_path: Path, site_dir: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    contract = load_contract(contract_path)
+    base_url = normalize_base_url(contract.get("production_base_url", ""))
+    routes, route_by_id, route_by_path = build_routes(contract)
+    edges, nav, handoffs, exceptions = load_actions(contract, route_by_id)
+    check_reachability(contract, routes, route_by_id, edges, nav, errors)
+
+    observed_edges: list[dict[str, Any]] = []
+    observed_handoffs: list[dict[str, Any]] = []
+    browser_required: list[dict[str, Any]] = []
+    seen_required_edges: set[tuple[str, str]] = set()
+
+    discovery = contract.get("discovery") or {}
+    if not isinstance(discovery, dict):
+        raise ValidationError("discovery must be an object")
+    sitemap_rel = discovery.get("sitemap", "sitemap.xml")
+    robots_rel = discovery.get("robots", "robots.txt")
+    describedby_rel = discovery.get("machine_description")
+    sitemap_url = urljoin(base_url, sitemap_rel)
+
+    expected_sitemap: dict[str, str | None] = {}
+    for route in routes:
+        if route.indexable:
+            expected_sitemap[route_url(base_url, route.path)] = route.lastmod
+
+    actual_sitemap = parse_sitemap(site_dir / sitemap_rel)
+    if set(actual_sitemap) != set(expected_sitemap):
+        missing = sorted(set(expected_sitemap) - set(actual_sitemap))
+        unexpected = sorted(set(actual_sitemap) - set(expected_sitemap))
+        if missing:
+            fail(errors, f"sitemap missing indexable canonical routes: {missing}")
+        if unexpected:
+            fail(errors, f"sitemap contains undeclared/non-indexable routes: {unexpected}")
+    for loc in sorted(set(actual_sitemap) & set(expected_sitemap)):
+        expected_lastmod = expected_sitemap[loc]
+        actual_lastmod = actual_sitemap[loc]
+        if expected_lastmod != actual_lastmod:
+            fail(errors, f"sitemap lastmod mismatch for {loc}: expected {expected_lastmod!r}, got {actual_lastmod!r}")
+
+    robot_sitemaps, robot_directives = parse_robots(site_dir / robots_rel)
+    if sitemap_url not in robot_sitemaps:
+        fail(errors, f"robots.txt must advertise canonical sitemap URL {sitemap_url}")
+    base_path = urlparse(base_url).path
+    for agent, directive in robot_directives:
+        if agent == "*" and directive.lower().startswith("disallow:"):
+            disallow = directive.split(":", 1)[1].strip()
+            if disallow in {"/", base_path, base_path.rstrip("/")}:
+                fail(errors, f"robots.txt blocks the production site for User-agent *: {directive}")
+
+    for route in routes:
+        file_path = local_file_for_route(site_dir, route.path)
+        if not file_path.exists():
+            if route.required:
+                fail(errors, f"missing required rendered route {route.id!r}: {file_path}")
+            continue
+        parser = parse_html(file_path)
+        if parser.states != [route.id]:
+            fail(errors, f"{route.id}: expected exactly data-surface-state={route.id!r}, observed {parser.states!r}")
+        if parser.title != route.title:
+            fail(errors, f"{route.id}: title mismatch: expected {route.title!r}, got {parser.title!r}")
+
+        canonical = route_url(base_url, route.path)
+        if parser.canonicals != [canonical]:
+            fail(errors, f"{route.id}: expected exactly canonical {canonical!r}, observed {parser.canonicals!r}")
+        noindex = any("noindex" in {t.strip().lower() for t in content.split(",")} for content in parser.meta_robots)
+        if route.indexable and noindex:
+            fail(errors, f"{route.id}: indexable route is marked noindex")
+        if not route.indexable and not noindex:
+            warnings.append(f"{route.id}: route is non-indexable by contract but page does not explicitly declare noindex")
+
+        if describedby_rel:
+            describedby_abs = urljoin(base_url, describedby_rel)
+            resolved = {urljoin(canonical, href) for href in parser.describedby}
+            if describedby_abs not in resolved:
+                fail(errors, f"{route.id}: missing rel=describedby discovery link to {describedby_abs}")
+
+        for item in parser.actions:
+            action = item["action"]
+            href = item["href"]
+            tag = item["tag"]
+            if not action:
+                if tag == "a" and href:
+                    fail(errors, f"{route.id}: rendered link {href!r} lacks data-surface-action classification")
+                elif tag == "button":
+                    fail(errors, f"{route.id}: rendered button lacks data-surface-action classification")
+                continue
+
+            edge = edges.get((route.id, action))
+            nav_item = nav.get(action)
+            handoff = handoffs.get(action)
+            exception = exceptions.get(action)
+            matched = sum(x is not None for x in (edge, nav_item, handoff, exception))
+            if matched == 0:
+                fail(errors, f"{route.id}: rendered action {action!r} is undeclared")
+                continue
+            if matched > 1:
+                fail(errors, f"{route.id}: rendered action {action!r} matches multiple classifications")
+                continue
+            if exception:
+                continue
+
+            if href is None:
+                if edge and bool(edge.get("browser_required", False)):
+                    browser_required.append({"from": route.id, "action": action, "to": edge["to"]})
+                    seen_required_edges.add((route.id, action))
+                elif nav_item and bool(nav_item.get("browser_required", False)):
+                    browser_required.append({"from": route.id, "action": action, "to": nav_item["to"]})
+                else:
+                    fail(errors, f"{route.id}: action {action!r} has no href and is not declared browser_required")
+                continue
+
+            absolute = urljoin(canonical, href)
+            same_origin, in_base = is_same_site(absolute, base_url)
+
+            if edge or nav_item:
+                target_id = edge["to"] if edge else nav_item["to"]
+                if same_origin and not in_base:
+                    fail(errors, f"{route.id}: internal action {action!r} escapes project base path: {absolute}")
+                    continue
+                if not same_origin:
+                    fail(errors, f"{route.id}: internal action {action!r} unexpectedly exits site: {absolute}")
+                    continue
+                observed_target = route_id_for_absolute(absolute, base_url, route_by_path)
+                if observed_target != target_id:
+                    fail(errors, f"{route.id}: action {action!r} targets {observed_target!r}/{absolute}, expected {target_id!r}")
+                    continue
+                observed_edges.append({"from": route.id, "action": action, "to": target_id, "class": "flow" if edge else nav_item["class"]})
+                if edge:
+                    seen_required_edges.add((route.id, action))
+                continue
+
+            if handoff:
+                if same_origin:
+                    fail(errors, f"{route.id}: external handoff {action!r} unexpectedly stays on same origin: {absolute}")
+                    continue
+                exact = handoff.get("url")
+                prefix = handoff.get("url_prefix")
+                if exact and absolute != exact:
+                    fail(errors, f"{route.id}: handoff {action!r} URL mismatch: {absolute!r} != {exact!r}")
+                    continue
+                if prefix and not absolute.startswith(prefix):
+                    fail(errors, f"{route.id}: handoff {action!r} URL {absolute!r} does not match prefix {prefix!r}")
+                    continue
+                declared_handoff = handoff.get("handoff")
+                observed_handoff = item.get("handoff")
+                if declared_handoff and observed_handoff != declared_handoff:
+                    fail(errors, f"{route.id}: handoff {action!r} requires data-surface-handoff={declared_handoff!r}, got {observed_handoff!r}")
+                    continue
+                observed_handoffs.append({"from": route.id, "action": action, "url": absolute})
+
+    for key, edge in edges.items():
+        if bool(edge.get("required_rendered", True)) and key not in seen_required_edges:
+            fail(errors, f"required rendered transition missing: {key[0]} --{key[1]}--> {edge['to']}")
+
+    evidence = {
+        "schema": "public-surface-conformance-evidence/1",
+        "contract_schema": SCHEMA,
+        "production_base_url": base_url,
+        "route_count": len(routes),
+        "expected_transition_count": len(edges),
+        "observed_edge_count": len(observed_edges),
+        "observed_handoff_count": len(observed_handoffs),
+        "browser_required_actions": sorted(browser_required, key=lambda x: (x["from"], x["action"], x["to"])),
+        "observed_edges": sorted(observed_edges, key=lambda x: (x["from"], x["action"], x["to"])),
+        "external_handoffs": sorted(observed_handoffs, key=lambda x: (x["from"], x["action"], x["url"])),
+        "sitemap_routes": sorted(actual_sitemap),
+        "warnings": sorted(warnings),
+        "errors": sorted(errors),
+        "verdict": "pass" if not errors else "fail",
+    }
+    return evidence
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--contract", required=True, type=Path)
+    parser.add_argument("--site-dir", required=True, type=Path)
+    parser.add_argument("--evidence", type=Path)
+    args = parser.parse_args()
+
+    try:
+        evidence = validate(args.contract, args.site_dir)
+    except ValidationError as exc:
+        evidence = {
+            "schema": "public-surface-conformance-evidence/1",
+            "contract_schema": SCHEMA,
+            "verdict": "fail",
+            "errors": [str(exc)],
+            "warnings": [],
+        }
+
+    encoded = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if args.evidence:
+        args.evidence.parent.mkdir(parents=True, exist_ok=True)
+        args.evidence.write_text(encoded, encoding="utf-8")
+    sys.stdout.write(encoded)
+    return 0 if evidence["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/public-web/validate-surface-contract.py
+++ b/scripts/public-web/validate-surface-contract.py
@@ -355,6 +355,63 @@ def parse_robots(path: Path) -> tuple[list[str], list[tuple[str, str, str]]]:
     return sitemaps, directives
 
 
+def validate_robots(
+    discovery: dict[str, Any],
+    production_base: str,
+    site_dir: Path,
+    sitemap_url: str,
+    errors: list[str],
+) -> dict[str, str]:
+    raw = discovery.get("robots")
+    if raw is None:
+        raise ValidationError("discovery.robots must explicitly declare local or origin-external authority")
+
+    if isinstance(raw, str):
+        config: dict[str, Any] = {"mode": "local", "path": raw}
+    elif isinstance(raw, dict):
+        config = raw
+    else:
+        raise ValidationError("discovery.robots must be a path string or object")
+
+    mode = config.get("mode")
+    prod = urlparse(production_base)
+    origin_robots = urlunparse((prod.scheme, prod.netloc, "/robots.txt", "", "", ""))
+
+    if mode == "local":
+        if prod.path not in {"", "/"}:
+            add_error(
+                errors,
+                "local robots.txt is invalid for a subpath-hosted production surface; declare origin-external authority instead",
+            )
+        path = config.get("path", "robots.txt")
+        if not isinstance(path, str) or not path or urlparse(path).scheme:
+            raise ValidationError("local robots path must be a relative candidate path")
+        sitemaps, directives = parse_robots(site_dir / path)
+        if sitemap_url not in sitemaps:
+            add_error(errors, f"robots.txt must advertise canonical sitemap URL {sitemap_url}")
+        for agent, kind, value in directives:
+            if agent == "*" and kind == "disallow" and value == "/":
+                add_error(errors, "robots.txt blocks the entire production origin for User-agent *")
+        return {"mode": "local", "url": origin_robots, "verification": "candidate"}
+
+    if mode == "origin-external":
+        value = config.get("url")
+        if not isinstance(value, str) or not value:
+            raise ValidationError("origin-external robots authority requires an absolute url")
+        parsed = urlparse(value)
+        if (
+            parsed.scheme != prod.scheme
+            or parsed.netloc != prod.netloc
+            or parsed.path != "/robots.txt"
+            or parsed.query
+            or parsed.fragment
+        ):
+            add_error(errors, f"origin-external robots URL must be the production origin root {origin_robots}")
+        return {"mode": "origin-external", "url": value, "verification": "deferred-live"}
+
+    raise ValidationError("discovery.robots mode must be 'local' or 'origin-external'")
+
+
 def same_origin_and_base(url: str, base: str) -> tuple[bool, bool]:
     u, b = urlparse(url), urlparse(base)
     same_origin = (u.scheme, u.netloc) == (b.scheme, b.netloc)
@@ -408,7 +465,8 @@ def validate(contract_path: Path, site_dir: Path, navigation_base_url: str | Non
     if not isinstance(discovery, dict):
         raise ValidationError("discovery must be an object")
     sitemap_rel = discovery.get("sitemap", "sitemap.xml")
-    robots_rel = discovery.get("robots", "robots.txt")
+    if not isinstance(sitemap_rel, str) or not sitemap_rel:
+        raise ValidationError("discovery.sitemap must be a relative candidate path")
     machine_rel = discovery.get("machine_description")
 
     expected_sitemap = {
@@ -427,13 +485,7 @@ def validate(contract_path: Path, site_dir: Path, navigation_base_url: str | Non
             add_error(errors, f"sitemap lastmod mismatch for {loc}: expected {expected_sitemap[loc]!r}, got {actual_sitemap[loc]!r}")
 
     sitemap_url = urljoin(production_base, sitemap_rel)
-    robot_sitemaps, robot_directives = parse_robots(site_dir / robots_rel)
-    if sitemap_url not in robot_sitemaps:
-        add_error(errors, f"robots.txt must advertise canonical sitemap URL {sitemap_url}")
-    production_path = urlparse(production_base).path
-    for agent, kind, value in robot_directives:
-        if agent == "*" and kind == "disallow" and value in {"/", production_path, production_path.rstrip("/")}:
-            add_error(errors, f"robots.txt blocks production site for User-agent *: Disallow: {value}")
+    robots_evidence = validate_robots(discovery, production_base, site_dir, sitemap_url, errors)
 
     if machine_rel and not urlparse(machine_rel).scheme:
         machine_path = site_dir / machine_rel.lstrip("/")
@@ -476,11 +528,7 @@ def validate(contract_path: Path, site_dir: Path, navigation_base_url: str | Non
 
         if machine_rel:
             parsed_machine = urlparse(machine_rel)
-            expected_machine = (
-                machine_rel
-                if parsed_machine.scheme
-                else urljoin(navigation_base, machine_rel.lstrip("/"))
-            )
+            expected_machine = machine_rel if parsed_machine.scheme else urljoin(navigation_base, machine_rel.lstrip("/"))
             resolved = {urljoin(candidate_page, href) for href in page.describedby}
             if expected_machine not in resolved:
                 add_error(errors, f"{route.id}: missing rel=describedby link to candidate machine description {expected_machine}")
@@ -608,6 +656,7 @@ def validate(contract_path: Path, site_dir: Path, navigation_base_url: str | Non
         "contract_schema": CONTRACT_SCHEMA,
         "production_base_url": production_base,
         "navigation_base_url": navigation_base,
+        "robots": robots_evidence,
         "route_count": len(routes),
         "expected_transition_count": len(transitions),
         "observed_edge_count": len(observed_edges),

--- a/tests/public-surface-conformance-selftest.py
+++ b/tests/public-surface-conformance-selftest.py
@@ -142,7 +142,7 @@ Sitemap: https://example.org/project/sitemap.xml
         )
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
-        self.assertTrue(any("escapes project base path" in e for e in evidence["errors"]))
+        self.assertTrue(any("escapes candidate project base path" in e for e in evidence["errors"]))
 
     def test_missing_sitemap_route_fails(self) -> None:
         path = self.site / "sitemap.xml"
@@ -193,6 +193,38 @@ Sitemap: https://example.org/project/sitemap.xml
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("lastmod mismatch" in e for e in evidence["errors"]))
+
+    def test_candidate_navigation_base_is_distinct_from_canonical_base(self) -> None:
+        index = self.site / "index.html"
+        use = self.site / "use" / "index.html"
+        index.write_text(
+            index.read_text(encoding="utf-8")
+            .replace('href="use/"', 'href="http://127.0.0.1:4173/use/"')
+            .replace('href="./"', 'href="http://127.0.0.1:4173/"'),
+            encoding="utf-8",
+        )
+        use.write_text(
+            use.read_text(encoding="utf-8")
+            .replace('href="../"', 'href="http://127.0.0.1:4173/"'),
+            encoding="utf-8",
+        )
+        evidence = module.validate(
+            self.contract_path, self.site, "http://127.0.0.1:4173/"
+        )
+        self.assertEqual("pass", evidence["verdict"])
+        self.assertEqual("https://example.org/project/", evidence["production_base_url"])
+        self.assertEqual("http://127.0.0.1:4173/", evidence["navigation_base_url"])
+
+    def test_rendered_dead_end_fails(self) -> None:
+        path = self.site / "use" / "index.html"
+        text = path.read_text(encoding="utf-8")
+        text = text.replace(
+            '<a data-surface-action="nav-home" href="../">Home</a>', ""
+        )
+        path.write_text(text, encoding="utf-8")
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("rendered dead end" in e for e in evidence["errors"]))
 
 
 if __name__ == "__main__":

--- a/tests/public-surface-conformance-selftest.py
+++ b/tests/public-surface-conformance-selftest.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "public-web" / "validate-surface-contract.py"
+spec = importlib.util.spec_from_file_location("surface_validator", VALIDATOR)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class SurfaceConformanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.site = self.root / "site"
+        (self.site / "use").mkdir(parents=True)
+        self.contract_path = self.root / "contract.json"
+        self.contract = {
+            "schema": "public-surface-contract/1",
+            "production_base_url": "https://example.org/project/",
+            "entry_states": ["home"],
+            "routes": [
+                {
+                    "id": "home",
+                    "path": "/",
+                    "title": "Example Project",
+                    "indexable": True,
+                    "required": True,
+                    "terminal": False,
+                },
+                {
+                    "id": "use",
+                    "path": "/use/",
+                    "title": "Use Example Project",
+                    "indexable": True,
+                    "required": True,
+                    "terminal": False,
+                },
+            ],
+            "transitions": [
+                {
+                    "from": "home",
+                    "action": "view-use",
+                    "to": "use",
+                    "required_rendered": True,
+                }
+            ],
+            "navigation": [
+                {"action": "nav-home", "class": "global", "to": "home"}
+            ],
+            "handoffs": [
+                {
+                    "action": "view-source",
+                    "handoff": "source",
+                    "url_prefix": "https://github.com/example/",
+                }
+            ],
+            "discovery": {
+                "sitemap": "sitemap.xml",
+                "robots": "robots.txt",
+                "machine_description": "surface.json",
+            },
+        }
+        self.contract_path.write_text(json.dumps(self.contract), encoding="utf-8")
+        (self.site / "surface.json").write_text("{}\n", encoding="utf-8")
+        (self.site / "index.html").write_text(
+            """<!doctype html>
+<html><head>
+<title>Example Project</title>
+<link rel="canonical" href="https://example.org/project/">
+<link rel="describedby" href="surface.json">
+</head><body>
+<main data-surface-state="home">
+<a data-surface-action="view-use" href="use/">Use</a>
+<a data-surface-action="nav-home" href="./">Home</a>
+<a data-surface-action="view-source" data-surface-handoff="source"
+   href="https://github.com/example/repo">Source</a>
+</main></body></html>
+""",
+            encoding="utf-8",
+        )
+        (self.site / "use" / "index.html").write_text(
+            """<!doctype html>
+<html><head>
+<title>Use Example Project</title>
+<link rel="canonical" href="https://example.org/project/use/">
+<link rel="describedby" href="../surface.json">
+</head><body>
+<main data-surface-state="use">
+<a data-surface-action="nav-home" href="../">Home</a>
+<a data-surface-action="view-source" data-surface-handoff="source"
+   href="https://github.com/example/repo">Source</a>
+</main></body></html>
+""",
+            encoding="utf-8",
+        )
+        (self.site / "sitemap.xml").write_text(
+            """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.org/project/</loc></url>
+  <url><loc>https://example.org/project/use/</loc></url>
+</urlset>
+""",
+            encoding="utf-8",
+        )
+        (self.site / "robots.txt").write_text(
+            """User-agent: *
+Allow: /
+
+Sitemap: https://example.org/project/sitemap.xml
+""",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def validate(self):
+        return module.validate(self.contract_path, self.site)
+
+    def test_valid_surface_passes(self) -> None:
+        evidence = self.validate()
+        self.assertEqual("pass", evidence["verdict"])
+        self.assertEqual([], evidence["errors"])
+        self.assertEqual(1, evidence["expected_transition_count"])
+
+    def test_project_base_path_escape_fails(self) -> None:
+        path = self.site / "index.html"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace('href="use/"', 'href="/outside/"'),
+            encoding="utf-8",
+        )
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("escapes project base path" in e for e in evidence["errors"]))
+
+    def test_missing_sitemap_route_fails(self) -> None:
+        path = self.site / "sitemap.xml"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "  <url><loc>https://example.org/project/use/</loc></url>\n", ""
+            ),
+            encoding="utf-8",
+        )
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("sitemap missing" in e for e in evidence["errors"]))
+
+    def test_unclassified_link_fails(self) -> None:
+        path = self.site / "index.html"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                '<a data-surface-action="view-use" href="use/">',
+                '<a href="use/">',
+            ),
+            encoding="utf-8",
+        )
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("lacks data-surface-action" in e for e in evidence["errors"]))
+
+    def test_accidental_noindex_fails(self) -> None:
+        path = self.site / "index.html"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "</head>", '<meta name="robots" content="noindex"></head>'
+            ),
+            encoding="utf-8",
+        )
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("marked noindex" in e for e in evidence["errors"]))
+
+    def test_undeclared_sitemap_lastmod_fails(self) -> None:
+        path = self.site / "sitemap.xml"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "<url><loc>https://example.org/project/</loc></url>",
+                "<url><loc>https://example.org/project/</loc><lastmod>2026-08-30</lastmod></url>",
+            ),
+            encoding="utf-8",
+        )
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("lastmod mismatch" in e for e in evidence["errors"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/public-surface-conformance-selftest.py
+++ b/tests/public-surface-conformance-selftest.py
@@ -47,11 +47,14 @@ class SurfaceConformanceTests(unittest.TestCase):
             ],
             "discovery": {
                 "sitemap": "sitemap.xml",
-                "robots": "robots.txt",
+                "robots": {
+                    "mode": "origin-external",
+                    "url": "https://example.org/robots.txt",
+                },
                 "machine_description": "surface.json",
             },
         }
-        self.contract_path.write_text(json.dumps(self.contract), encoding="utf-8")
+        self.write_contract()
         (self.site / "surface.json").write_text("{}\n", encoding="utf-8")
         (self.site / "index.html").write_text(
             """<!doctype html><html><head>
@@ -97,6 +100,9 @@ class SurfaceConformanceTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp.cleanup()
 
+    def write_contract(self) -> None:
+        self.contract_path.write_text(json.dumps(self.contract), encoding="utf-8")
+
     def validate(self, navigation_base=None):
         return module.validate(self.contract_path, self.site, navigation_base)
 
@@ -106,6 +112,8 @@ class SurfaceConformanceTests(unittest.TestCase):
         self.assertEqual([], evidence["errors"])
         self.assertEqual(1, evidence["expected_transition_count"])
         self.assertEqual(1, evidence["observed_resource_count"])
+        self.assertEqual("origin-external", evidence["robots"]["mode"])
+        self.assertEqual("deferred-live", evidence["robots"]["verification"])
 
     def test_project_base_path_escape_fails(self) -> None:
         path = self.site / "index.html"
@@ -179,6 +187,32 @@ class SurfaceConformanceTests(unittest.TestCase):
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("required rendered resource missing" in e for e in evidence["errors"]))
+
+    def test_local_robots_is_rejected_for_subpath_surface(self) -> None:
+        self.contract["discovery"]["robots"] = {"mode": "local", "path": "robots.txt"}
+        self.write_contract()
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("local robots.txt is invalid for a subpath-hosted production surface" in e for e in evidence["errors"]))
+
+    def test_origin_root_surface_can_validate_local_robots(self) -> None:
+        self.contract["production_base_url"] = "https://example.org/"
+        self.contract["discovery"]["robots"] = {"mode": "local", "path": "robots.txt"}
+        self.write_contract()
+
+        index = self.site / "index.html"
+        index.write_text(index.read_text().replace("https://example.org/project/", "https://example.org/"), encoding="utf-8")
+        use = self.site / "use" / "index.html"
+        use.write_text(use.read_text().replace("https://example.org/project/use/", "https://example.org/use/"), encoding="utf-8")
+        sitemap = self.site / "sitemap.xml"
+        sitemap.write_text(sitemap.read_text().replace("https://example.org/project/", "https://example.org/"), encoding="utf-8")
+        robots = self.site / "robots.txt"
+        robots.write_text("User-agent: *\nAllow: /\n\nSitemap: https://example.org/sitemap.xml\n", encoding="utf-8")
+
+        evidence = self.validate()
+        self.assertEqual("pass", evidence["verdict"])
+        self.assertEqual("local", evidence["robots"]["mode"])
+        self.assertEqual("candidate", evidence["robots"]["verification"])
 
 
 if __name__ == "__main__":

--- a/tests/public-surface-conformance-selftest.py
+++ b/tests/public-surface-conformance-selftest.py
@@ -8,7 +8,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 VALIDATOR = ROOT / "scripts" / "public-web" / "validate-surface-contract.py"
 spec = importlib.util.spec_from_file_location("surface_validator", VALIDATOR)
@@ -30,40 +29,21 @@ class SurfaceConformanceTests(unittest.TestCase):
             "production_base_url": "https://example.org/project/",
             "entry_states": ["home"],
             "routes": [
-                {
-                    "id": "home",
-                    "path": "/",
-                    "title": "Example Project",
-                    "indexable": True,
-                    "required": True,
-                    "terminal": False,
-                },
-                {
-                    "id": "use",
-                    "path": "/use/",
-                    "title": "Use Example Project",
-                    "indexable": True,
-                    "required": True,
-                    "terminal": False,
-                },
+                {"id": "home", "path": "/", "title": "Example Project", "indexable": True, "required": True, "terminal": False},
+                {"id": "use", "path": "/use/", "title": "Use Example Project", "indexable": True, "required": True, "terminal": False},
             ],
             "transitions": [
-                {
-                    "from": "home",
-                    "action": "view-use",
-                    "to": "use",
-                    "required_rendered": True,
-                }
+                {"from": "home", "action": "view-use", "to": "use", "required_rendered": True}
             ],
             "navigation": [
-                {"action": "nav-home", "class": "global", "to": "home"}
+                {"action": "nav-home", "class": "global", "to": "home"},
+                {"action": "skip-main", "class": "utility", "to": "$self"},
+            ],
+            "resources": [
+                {"action": "machine-project", "path": "/surface.json", "required_on": ["home"]}
             ],
             "handoffs": [
-                {
-                    "action": "view-source",
-                    "handoff": "source",
-                    "url_prefix": "https://github.com/example/",
-                }
+                {"action": "view-source", "handoff": "source", "url_prefix": "https://github.com/example/"}
             ],
             "discovery": {
                 "sitemap": "sitemap.xml",
@@ -74,34 +54,31 @@ class SurfaceConformanceTests(unittest.TestCase):
         self.contract_path.write_text(json.dumps(self.contract), encoding="utf-8")
         (self.site / "surface.json").write_text("{}\n", encoding="utf-8")
         (self.site / "index.html").write_text(
-            """<!doctype html>
-<html><head>
+            """<!doctype html><html><head>
 <title>Example Project</title>
 <link rel="canonical" href="https://example.org/project/">
 <link rel="describedby" href="surface.json">
 </head><body>
-<main data-surface-state="home">
+<a data-surface-action="skip-main" href="#main">Skip</a>
+<main id="main" data-surface-state="home">
 <a data-surface-action="view-use" href="use/">Use</a>
 <a data-surface-action="nav-home" href="./">Home</a>
-<a data-surface-action="view-source" data-surface-handoff="source"
-   href="https://github.com/example/repo">Source</a>
-</main></body></html>
-""",
+<a data-surface-action="machine-project" href="surface.json">Machine</a>
+<a data-surface-action="view-source" data-surface-handoff="source" href="https://github.com/example/repo">Source</a>
+</main></body></html>\n""",
             encoding="utf-8",
         )
         (self.site / "use" / "index.html").write_text(
-            """<!doctype html>
-<html><head>
+            """<!doctype html><html><head>
 <title>Use Example Project</title>
 <link rel="canonical" href="https://example.org/project/use/">
 <link rel="describedby" href="../surface.json">
 </head><body>
-<main data-surface-state="use">
+<a data-surface-action="skip-main" href="#main">Skip</a>
+<main id="main" data-surface-state="use">
 <a data-surface-action="nav-home" href="../">Home</a>
-<a data-surface-action="view-source" data-surface-handoff="source"
-   href="https://github.com/example/repo">Source</a>
-</main></body></html>
-""",
+<a data-surface-action="view-source" data-surface-handoff="source" href="https://github.com/example/repo">Source</a>
+</main></body></html>\n""",
             encoding="utf-8",
         )
         (self.site / "sitemap.xml").write_text(
@@ -109,122 +86,99 @@ class SurfaceConformanceTests(unittest.TestCase):
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://example.org/project/</loc></url>
   <url><loc>https://example.org/project/use/</loc></url>
-</urlset>
-""",
+</urlset>\n""",
             encoding="utf-8",
         )
         (self.site / "robots.txt").write_text(
-            """User-agent: *
-Allow: /
-
-Sitemap: https://example.org/project/sitemap.xml
-""",
+            "User-agent: *\nAllow: /\n\nSitemap: https://example.org/project/sitemap.xml\n",
             encoding="utf-8",
         )
 
     def tearDown(self) -> None:
         self.temp.cleanup()
 
-    def validate(self):
-        return module.validate(self.contract_path, self.site)
+    def validate(self, navigation_base=None):
+        return module.validate(self.contract_path, self.site, navigation_base)
 
     def test_valid_surface_passes(self) -> None:
         evidence = self.validate()
         self.assertEqual("pass", evidence["verdict"])
         self.assertEqual([], evidence["errors"])
         self.assertEqual(1, evidence["expected_transition_count"])
+        self.assertEqual(1, evidence["observed_resource_count"])
 
     def test_project_base_path_escape_fails(self) -> None:
         path = self.site / "index.html"
-        path.write_text(
-            path.read_text(encoding="utf-8").replace('href="use/"', 'href="/outside/"'),
-            encoding="utf-8",
-        )
+        path.write_text(path.read_text().replace('href="use/"', 'href="/outside/"'), encoding="utf-8")
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("escapes candidate project base path" in e for e in evidence["errors"]))
 
     def test_missing_sitemap_route_fails(self) -> None:
         path = self.site / "sitemap.xml"
-        path.write_text(
-            path.read_text(encoding="utf-8").replace(
-                "  <url><loc>https://example.org/project/use/</loc></url>\n", ""
-            ),
-            encoding="utf-8",
-        )
+        path.write_text(path.read_text().replace("  <url><loc>https://example.org/project/use/</loc></url>\n", ""), encoding="utf-8")
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("sitemap missing" in e for e in evidence["errors"]))
 
     def test_unclassified_link_fails(self) -> None:
         path = self.site / "index.html"
-        path.write_text(
-            path.read_text(encoding="utf-8").replace(
-                '<a data-surface-action="view-use" href="use/">',
-                '<a href="use/">',
-            ),
-            encoding="utf-8",
-        )
+        path.write_text(path.read_text().replace('data-surface-action="view-use" ', ""), encoding="utf-8")
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("lacks data-surface-action" in e for e in evidence["errors"]))
 
     def test_accidental_noindex_fails(self) -> None:
         path = self.site / "index.html"
-        path.write_text(
-            path.read_text(encoding="utf-8").replace(
-                "</head>", '<meta name="robots" content="noindex"></head>'
-            ),
-            encoding="utf-8",
-        )
+        path.write_text(path.read_text().replace("</head>", '<meta name="robots" content="noindex"></head>'), encoding="utf-8")
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("marked noindex" in e for e in evidence["errors"]))
 
     def test_undeclared_sitemap_lastmod_fails(self) -> None:
         path = self.site / "sitemap.xml"
-        path.write_text(
-            path.read_text(encoding="utf-8").replace(
-                "<url><loc>https://example.org/project/</loc></url>",
-                "<url><loc>https://example.org/project/</loc><lastmod>2026-08-30</lastmod></url>",
-            ),
-            encoding="utf-8",
-        )
+        path.write_text(path.read_text().replace(
+            "<url><loc>https://example.org/project/</loc></url>",
+            "<url><loc>https://example.org/project/</loc><lastmod>2026-08-30</lastmod></url>"
+        ), encoding="utf-8")
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("lastmod mismatch" in e for e in evidence["errors"]))
 
     def test_candidate_navigation_base_is_distinct_from_canonical_base(self) -> None:
-        index = self.site / "index.html"
-        use = self.site / "use" / "index.html"
-        index.write_text(
-            index.read_text(encoding="utf-8")
-            .replace('href="use/"', 'href="http://127.0.0.1:4173/use/"')
-            .replace('href="./"', 'href="http://127.0.0.1:4173/"'),
-            encoding="utf-8",
-        )
-        use.write_text(
-            use.read_text(encoding="utf-8")
-            .replace('href="../"', 'href="http://127.0.0.1:4173/"'),
-            encoding="utf-8",
-        )
-        evidence = module.validate(
-            self.contract_path, self.site, "http://127.0.0.1:4173/"
-        )
+        for path in [self.site / "index.html", self.site / "use" / "index.html"]:
+            text = path.read_text(encoding="utf-8")
+            text = text.replace('href="use/"', 'href="http://127.0.0.1:4173/use/"')
+            text = text.replace('href="./"', 'href="http://127.0.0.1:4173/"')
+            text = text.replace('href="../"', 'href="http://127.0.0.1:4173/"')
+            text = text.replace('href="surface.json"', 'href="http://127.0.0.1:4173/surface.json"')
+            path.write_text(text, encoding="utf-8")
+        evidence = self.validate("http://127.0.0.1:4173/")
         self.assertEqual("pass", evidence["verdict"])
         self.assertEqual("https://example.org/project/", evidence["production_base_url"])
         self.assertEqual("http://127.0.0.1:4173/", evidence["navigation_base_url"])
 
-    def test_rendered_dead_end_fails(self) -> None:
+    def test_rendered_dead_end_fails_even_with_skip_self_link(self) -> None:
         path = self.site / "use" / "index.html"
-        text = path.read_text(encoding="utf-8")
-        text = text.replace(
-            '<a data-surface-action="nav-home" href="../">Home</a>', ""
-        )
-        path.write_text(text, encoding="utf-8")
+        path.write_text(path.read_text().replace('<a data-surface-action="nav-home" href="../">Home</a>\n', ""), encoding="utf-8")
         evidence = self.validate()
         self.assertEqual("fail", evidence["verdict"])
         self.assertTrue(any("rendered dead end" in e for e in evidence["errors"]))
+
+    def test_machine_resource_wrong_path_fails(self) -> None:
+        path = self.site / "index.html"
+        path.write_text(path.read_text().replace('href="surface.json">Machine', 'href="wrong.json">Machine'), encoding="utf-8")
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("resource 'machine-project' path mismatch" in e for e in evidence["errors"]))
+
+    def test_required_machine_resource_missing_fails(self) -> None:
+        path = self.site / "index.html"
+        line = '<a data-surface-action="machine-project" href="surface.json">Machine</a>\n'
+        path.write_text(path.read_text().replace(line, ""), encoding="utf-8")
+        evidence = self.validate()
+        self.assertEqual("fail", evidence["verdict"])
+        self.assertTrue(any("required rendered resource missing" in e for e in evidence["errors"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #33. Advances #32.

## Summary

Adds the first reusable implementation slice for the extended `GOV-WEB-001` public-surface contract:

- dependency-free, read-only `scripts/public-web/validate-surface-contract.py`;
- normalized `public-surface-contract/1` consumer contract;
- deterministic model/reachability and rendered action classification;
- separate canonical-production vs candidate-navigation identities;
- first-class human flow/global/utility navigation, same-site machine resources, external handoffs, and narrow exceptions;
- `$self` utility navigation for same-page actions such as skip links without falsely treating them as recovery edges;
- GitHub Pages project-base-path containment;
- rendered dead-end/recovery detection;
- canonical/title/indexability/Sitemap/discovery validation;
- standards-correct robots authority: origin-root sites may validate candidate `/robots.txt`; shared-origin subpath sites declare origin-external `/robots.txt` and defer that live check;
- explicit truthful `lastmod` behavior (omitted unless declared by authoritative project metadata);
- deterministic `public-surface-conformance-evidence/1` output;
- positive/negative self-tests and a public-safe CI workflow;
- documentation of the boundary with Playwright/axe/Lighthouse/Lychee.

## Generator/Validator boundary

Consumer repositories remain the generators/semantic authorities for routes, flow IDs, critical journeys, machine interfaces, indexability and candidate bytes. This repository supplies a generic validator. The validator does not infer function from CSS/position/copy and does not become a central route registry.

## Pilot feedback already incorporated

Read-only discovery of `SupraCraft/Bridge` exposed three important assumptions before adoption:

1. candidate navigation links intentionally target the local candidate server while canonical URLs remain production URLs, so the validator separates `production_base_url` from CLI `--navigation-base`;
2. same-page utility links and same-site machine endpoints are legitimate rendered actions but should not be forced into human flow states or `exceptions`, so `$self` navigation and `resources` are first-class contract concepts;
3. a GitHub Pages project site under `/Bridge/` does not own the origin-root `/robots.txt`; generating `/Bridge/robots.txt` would falsely claim crawler control, so robots authority is now explicit as `local` or `origin-external`.

The validator is changed to fit correct project/platform semantics rather than weakening/restructuring Bridge to fit the validator.

## Browser boundary

The static validator intentionally does not execute JavaScript. A transition can be marked `browser_required`; the validator records it for consumer-owned Playwright evidence instead of claiming a static proof.

## Validation posture

The synthetic suite covers valid and intentionally invalid surface/model/discovery cases. Repository CI at the final exact head is the independent validation gate; no merge should rely only on local fixtures. The existing public-site readiness self-test must also remain green so this new static validator does not perturb the already-proven Playwright/axe/Lighthouse/Lychee reusable workflow.

## R4

The validator is read-only and deterministic: exact candidate bytes + exact consumer contract + exact validator revision determine the result. It is repeatable by a fresh actor, requires no rollback, and is idempotent on unchanged inputs.

## Follow-on pilots

- `SupraCraft/Bridge#48`
- `SupraCraft/VanillaCord#57`

Do not merge pilot semantics into this repository; only mechanics proven reusable by both belong here.