### PR TITLE
Extract two-consumer static HCI Playwright helper

### DIFF
--- a/.github/workflows/public-site-readiness-selftest.yml
+++ b/.github/workflows/public-site-readiness-selftest.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/public-site-readiness.yml'
       - '.github/workflows/public-site-readiness-selftest.yml'
+      - 'scripts/public-web/static-hci-playwright.mjs'
       - 'tests/fixtures/public-site-readiness/**'
       - 'docs/public-site-release-readiness.md'
       - 'README.md'
@@ -14,6 +15,7 @@ on:
     paths:
       - '.github/workflows/public-site-readiness.yml'
       - '.github/workflows/public-site-readiness-selftest.yml'
+      - 'scripts/public-web/static-hci-playwright.mjs'
       - 'tests/fixtures/public-site-readiness/**'
       - 'docs/public-site-release-readiness.md'
       - 'README.md'

--- a/docs/static-hci-playwright.md
+++ b/docs/static-hci-playwright.md
@@ -1,0 +1,104 @@
+# Reusable static-HCI Playwright assertions
+
+`scripts/public-web/static-hci-playwright.mjs` contains the small automation-only HCI subset proven across two independent SupraCraft public-site consumers.
+
+It is intentionally a helper for a consumer's existing Playwright suite, not a second browser harness and not a product design system. Routes, selectors, critical journeys, tooltip behavior, branding, and application semantics remain consumer-owned.
+
+## Proven common assertions
+
+The helper exports:
+
+- `assertDocumentStructure` — descriptive title, one non-empty page-purpose H1, non-skipping downward heading hierarchy, and a narrow check against empty/context-free standalone action names;
+- `assertPrimaryTargets` — rendered target-box checks for consumer-declared primary controls, with 44 CSS pixels as the current default project target;
+- `assertKeyboardFocusPath` — actual `Tab` traversal across consumer-declared critical controls, viewport convergence through browser-owned focus/scroll behavior, then visible-center obstruction checking;
+- `assertSvgGeometry` — usable `viewBox`, non-zero rendered dimensions, and intended aspect-ratio checking for consumer-declared SVG graphics.
+
+Consumers choose applicability explicitly. Do not point the target-size assertion at every inline prose link, and do not invent an SVG requirement for a surface that has no applicable scalable control graphics.
+
+## Keyboard/focus invariant
+
+The keyboard helper preserves the input modality it claims to test. It sends real Playwright keyboard `Tab` input and never calls `focus()`, `scrollIntoView()`, or synthetic scrolling to make a control pass.
+
+A real focus transfer can trigger asynchronous browser-owned scrolling, especially when a surface uses `scroll-behavior: smooth`. Chromium and WebKit may therefore report the newly focused control before its normal focus scroll has converged. The helper waits for the **same still-focused declared control** to intersect the viewport, then checks that its visible center is not obscured. This is a state-convergence wait, not a substitute interaction.
+
+The helper deliberately does not treat mobile device emulation as proof of OS-level external-keyboard scrolling. Consumers should invoke keyboard-path checks only in browser profiles that actually model the keyboard behavior being claimed; a narrow desktop viewport is appropriate when the requirement is keyboard behavior under responsive layout.
+
+## Consumer pattern
+
+Pin the helper to a reviewed immutable `github-ops-lab` revision, place that exact file in a repository-local CI/helper location, and import it from the consumer's existing Playwright spec. For example:
+
+```js
+import { test, expect } from '@playwright/test';
+import {
+  assertDocumentStructure,
+  assertKeyboardFocusPath,
+  assertPrimaryTargets,
+  assertSvgGeometry,
+} from '../.ci/static-hci-playwright.mjs';
+
+test('homepage satisfies shared static HCI invariants', async ({ page }, testInfo) => {
+  await page.goto('/');
+
+  await assertDocumentStructure({
+    page,
+    expect,
+    label: `${testInfo.project.name} homepage`,
+  });
+
+  await assertPrimaryTargets({
+    page,
+    expect,
+    selector: '.declared-primary-control',
+    label: `${testInfo.project.name} homepage`,
+  });
+});
+```
+
+Keyboard evidence remains a separate applicability decision:
+
+```js
+test('narrow desktop keyboard path remains reachable', async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.startsWith('desktop-'));
+  await page.setViewportSize({ width: 320, height: 800 });
+  await page.goto('/');
+
+  await assertKeyboardFocusPath({
+    page,
+    expect,
+    selector: '.declared-keyboard-primary',
+    label: `${testInfo.project.name} 320px homepage`,
+  });
+});
+```
+
+The fetched helper revision is part of release-readiness evidence and should be visible in the consumer workflow or repository-local pin so later runs can be reproduced.
+
+## Two-consumer provenance
+
+### SupraCraft/Bridge
+
+- pilot PR `#51`;
+- qualified head `47246d3f9f61ca82d5bc5608fffaa2def375cd85`;
+- merged production revision `6ab755cda7a4b4cc03f132f1c2b6345c72ea9afd`;
+- production Pages run `33299901550`;
+- validator lesson tracked in Bridge issue `#52`.
+
+Bridge established that programmatic focus/mobile emulation must not be substituted for actual keyboard-modality evidence.
+
+### SupraCraft/VanillaCord
+
+- pilot PR `#61`;
+- first rebased candidate `0356046a3c0478e0b386524b64aea3d72dbb7efe`;
+- readiness run `33306063467` exposed the same-turn smooth focus-scroll timing assumption in Chromium/WebKit;
+- corrected qualified head `8e77e4e8782c406231cc15fc68c4069715760b59`;
+- merged production revision `c4b4c5c6aace99b936d9b68576b49c32d9775338`;
+- post-merge readiness run `33307252201`;
+- production Pages run `33307252171`.
+
+VanillaCord independently reproduced the shared invariants and refined the keyboard helper to wait for native focus-scroll convergence before geometry measurement.
+
+## Self-test
+
+The existing public-site-readiness self-test imports this helper directly. Its synthetic fixture deliberately uses smooth scrolling and places a declared keyboard target below the initial 320px desktop viewport. The Playwright matrix therefore regression-tests the timing boundary that the second consumer exposed rather than merely testing a page where every focus target is already visible.
+
+Keep product-specific selectors and behavior out of this helper. Add a new generic assertion only after it has objective semantics and independent consumer evidence.

--- a/scripts/public-web/static-hci-playwright.mjs
+++ b/scripts/public-web/static-hci-playwright.mjs
@@ -1,0 +1,177 @@
+const defaultGenericStandaloneName = /^(?:click here|here|more|read more|learn more|link|button|open)$/i;
+
+function requireSelector(selector, name) {
+  if (typeof selector !== 'string' || selector.trim() === '') {
+    throw new TypeError(`${name} must be a non-empty selector string`);
+  }
+  return selector;
+}
+
+export async function assertDocumentStructure({
+  page,
+  expect,
+  label = 'page',
+  titlePattern = null,
+  standaloneActionSelector = 'a[href], button',
+  genericStandaloneName = defaultGenericStandaloneName,
+}) {
+  const title = (await page.title()).trim();
+  expect(title.length, `${label} needs a descriptive document title`).toBeGreaterThanOrEqual(4);
+  if (titlePattern) expect(title, `${label} document title`).toMatch(titlePattern);
+
+  const h1 = page.locator('h1');
+  await expect(h1, `${label} should have one page-purpose heading`).toHaveCount(1);
+  expect((await h1.textContent())?.trim().length || 0, `${label} H1 should not be empty`).toBeGreaterThanOrEqual(3);
+
+  const headings = await page.locator('h1,h2,h3,h4,h5,h6').evaluateAll(nodes => nodes.map(node => Number(node.tagName.slice(1))));
+  for (let index = 1; index < headings.length; index += 1) {
+    expect(headings[index] - headings[index - 1], `${label} heading levels should not skip downward`).toBeLessThanOrEqual(1);
+  }
+
+  const standaloneActions = page.locator(standaloneActionSelector);
+  for (let index = 0; index < await standaloneActions.count(); index += 1) {
+    const name = await standaloneActions.nth(index).evaluate(node => {
+      const explicit = node.getAttribute('aria-label')?.trim();
+      return (explicit || node.textContent || '').replace(/\s+/g, ' ').trim();
+    });
+    expect(name.length, `${label} standalone action ${index} should not be unnamed`).toBeGreaterThan(0);
+    expect(genericStandaloneName.test(name), `${label} standalone action ${index} should not use a context-free generic label: ${name}`).toBe(false);
+  }
+}
+
+export async function assertPrimaryTargets({
+  page,
+  expect,
+  selector,
+  label = 'page',
+  minimumCssPixels = 44,
+}) {
+  const primarySelector = requireSelector(selector, 'selector');
+  const controls = page.locator(primarySelector);
+  expect(await controls.count(), `${label} should expose declared primary controls`).toBeGreaterThan(0);
+
+  for (let index = 0; index < await controls.count(); index += 1) {
+    const control = controls.nth(index);
+    await expect(control, `${label} primary control ${index}`).toBeVisible();
+    const geometry = await control.evaluate(node => {
+      const rect = node.getBoundingClientRect();
+      return { width: rect.width, height: rect.height };
+    });
+    expect(geometry.width, `${label} primary control ${index} width`).toBeGreaterThanOrEqual(minimumCssPixels);
+    expect(geometry.height, `${label} primary control ${index} height`).toBeGreaterThanOrEqual(minimumCssPixels);
+  }
+}
+
+export async function assertKeyboardFocusPath({
+  page,
+  expect,
+  selector,
+  label = 'page',
+  minimumTabBudget = 24,
+  tabBudgetMultiplier = 3,
+  convergenceTimeoutMs = 5000,
+}) {
+  const keyboardPrimarySelector = requireSelector(selector, 'selector');
+  const expected = await page.locator(keyboardPrimarySelector).count();
+  expect(expected, `${label} should expose keyboard-primary controls`).toBeGreaterThan(0);
+
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    window.scrollTo(0, 0);
+  });
+
+  const seen = new Set();
+  const maxTabs = Math.max(minimumTabBudget, expected * tabBudgetMultiplier);
+  for (let tabIndex = 0; tabIndex < maxTabs && seen.size < expected; tabIndex += 1) {
+    await page.keyboard.press('Tab');
+
+    const focused = await page.evaluate(selectorValue => {
+      const nodes = [...document.querySelectorAll(selectorValue)];
+      const ordinal = nodes.indexOf(document.activeElement);
+      if (ordinal < 0) return { primary: false, ordinal: -1, description: '' };
+      const node = nodes[ordinal];
+      const text = (node.getAttribute('aria-label') || node.textContent || '').replace(/\s+/g, ' ').trim();
+      return {
+        primary: true,
+        ordinal,
+        description: [node.tagName, node.getAttribute('href') || '', node.getAttribute('name') || '', node.getAttribute('value') || '', text].join('|'),
+      };
+    }, keyboardPrimarySelector);
+
+    if (!focused.primary) continue;
+
+    await expect.poll(async () => page.evaluate(({ selectorValue, ordinal }) => {
+      const nodes = [...document.querySelectorAll(selectorValue)];
+      const node = nodes[ordinal];
+      if (!(node instanceof HTMLElement) || document.activeElement !== node) return false;
+
+      const rect = node.getBoundingClientRect();
+      const left = Math.max(rect.left, 0);
+      const right = Math.min(rect.right, innerWidth);
+      const top = Math.max(rect.top, 0);
+      const bottom = Math.min(rect.bottom, innerHeight);
+      return right > left && bottom > top;
+    }, { selectorValue: keyboardPrimarySelector, ordinal: focused.ordinal }), {
+      message: `${label} keyboard-focused ${focused.description} must become visible through browser-owned focus/scroll handling`,
+      timeout: convergenceTimeoutMs,
+    }).toBe(true);
+
+    const obscured = await page.evaluate(({ selectorValue, ordinal }) => {
+      const nodes = [...document.querySelectorAll(selectorValue)];
+      const node = nodes[ordinal];
+      if (!(node instanceof HTMLElement) || document.activeElement !== node) return true;
+
+      const rect = node.getBoundingClientRect();
+      const left = Math.max(rect.left, 0);
+      const right = Math.min(rect.right, innerWidth);
+      const top = Math.max(rect.top, 0);
+      const bottom = Math.min(rect.bottom, innerHeight);
+      if (right <= left || bottom <= top) return true;
+
+      const x = (left + right) / 2;
+      const y = (top + bottom) / 2;
+      const topElement = document.elementFromPoint(x, y);
+      return Boolean(topElement && topElement !== node && !node.contains(topElement) && !topElement.contains(node));
+    }, { selectorValue: keyboardPrimarySelector, ordinal: focused.ordinal });
+
+    expect(obscured, `${label} keyboard-focused ${focused.description} must not be obscured at its visible center`).toBe(false);
+    seen.add(focused.ordinal);
+  }
+
+  expect(seen.size, `${label} keyboard traversal should reach every declared primary tab stop`).toBe(expected);
+}
+
+export async function assertSvgGeometry({
+  page,
+  expect,
+  selector,
+  label = 'page',
+  expectedViewBox = null,
+  intendedAspectRatio = 1,
+  aspectTolerance = 0.05,
+}) {
+  const svgSelector = requireSelector(selector, 'selector');
+  const icons = page.locator(svgSelector);
+  expect(await icons.count(), `${label} should expose declared SVG graphics`).toBeGreaterThan(0);
+
+  for (let index = 0; index < await icons.count(); index += 1) {
+    const icon = icons.nth(index);
+    if (expectedViewBox !== null) {
+      await expect(icon, `${label} SVG ${index} viewBox`).toHaveAttribute('viewBox', expectedViewBox);
+    } else {
+      const viewBox = await icon.getAttribute('viewBox');
+      expect(Boolean(viewBox?.trim()), `${label} SVG ${index} needs a usable viewBox`).toBe(true);
+    }
+
+    const geometry = await icon.evaluate(node => {
+      const rect = node.getBoundingClientRect();
+      return { width: rect.width, height: rect.height };
+    });
+    expect(geometry.width, `${label} SVG ${index} rendered width`).toBeGreaterThan(0);
+    expect(geometry.height, `${label} SVG ${index} rendered height`).toBeGreaterThan(0);
+    expect(
+      Math.abs(geometry.width / geometry.height - intendedAspectRatio),
+      `${label} SVG ${index} should preserve its intended aspect ratio`,
+    ).toBeLessThan(aspectTolerance);
+  }
+}

--- a/tests/fixtures/public-site-readiness/scripts/build.mjs
+++ b/tests/fixtures/public-site-readiness/scripts/build.mjs
@@ -13,15 +13,18 @@ const shell = ({ title, heading, body, current }) => `<!doctype html>
   <meta name="theme-color" content="#ffffff" data-effective-theme="light">
   <title>${title}</title>
   <style>
-    :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
+    :root { color-scheme: light dark; font-family: system-ui, sans-serif; scroll-behavior: smooth; }
     body { margin: 0; line-height: 1.5; }
     .skip { position: absolute; left: .5rem; top: -4rem; padding: .75rem; background: Canvas; color: CanvasText; }
     .skip:focus { top: .5rem; }
     header, main, footer { max-width: 60rem; margin: auto; padding: 1rem; }
     nav { display: flex; flex-wrap: wrap; gap: .75rem; align-items: center; }
-    a, select { min-height: 2rem; }
+    nav a, a.hci-primary { min-width: 44px; min-height: 44px; display: inline-flex; align-items: center; gap: .4rem; }
+    select { min-width: 44px; min-height: 44px; }
     main:focus { outline: 2px solid currentColor; outline-offset: 2px; }
     pre { overflow-x: auto; }
+    .hci-focus-scroll-spacer { min-height: 56rem; }
+    .hci-icon { width: 1rem; height: 1rem; flex: none; }
   </style>
 </head>
 <body>
@@ -68,12 +71,17 @@ fs.writeFileSync(path.join(out, 'index.html'), shell({
   title: 'Public-site readiness self-test',
   heading: 'Public-site readiness self-test',
   current: 'home',
-  body: '<p>This synthetic candidate proves the reusable release-readiness workflow without project-specific product behavior.</p><p><a href="./accessibility/">Review accessibility notes</a></p>'
+  body: `<p>This synthetic candidate proves the reusable release-readiness workflow without project-specific product behavior.</p>
+    <div class="hci-focus-scroll-spacer" aria-hidden="true"></div>
+    <p><a class="hci-primary" href="./accessibility/">
+      <svg class="hci-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M5 12h12M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2"/></svg>
+      <span>Review accessibility notes</span>
+    </a></p>`
 }));
 
 fs.writeFileSync(path.join(out, 'accessibility', 'index.html'), shell({
   title: 'Accessibility - public-site readiness self-test',
   heading: 'Accessibility',
   current: 'accessibility',
-  body: '<p>Automated checks are evidence, not certification. Manual accessibility review remains a consumer responsibility.</p>'
+  body: '<p>Automated checks are evidence, not certification. Manual accessibility review may still be appropriate when a consumer workset explicitly requires it.</p>'
 }));

--- a/tests/fixtures/public-site-readiness/tests/site/static-hci-shared.spec.mjs
+++ b/tests/fixtures/public-site-readiness/tests/site/static-hci-shared.spec.mjs
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import {
+  assertDocumentStructure,
+  assertKeyboardFocusPath,
+  assertPrimaryTargets,
+  assertSvgGeometry,
+} from '../../../../../scripts/public-web/static-hci-playwright.mjs';
+
+for (const route of ['/', '/accessibility/']) {
+  test(`${route} satisfies shared static-HCI structure and target invariants`, async ({ page }, testInfo) => {
+    const response = await page.goto(route, { waitUntil: 'networkidle' });
+    expect(response?.status()).toBeLessThan(400);
+
+    await assertDocumentStructure({
+      page,
+      expect,
+      label: `${testInfo.project.name} ${route}`,
+      titlePattern: /(?:self-test|Accessibility)/i,
+    });
+
+    await assertPrimaryTargets({
+      page,
+      expect,
+      selector: 'nav a, #theme-select',
+      label: `${testInfo.project.name} ${route}`,
+    });
+  });
+}
+
+test('shared SVG geometry helper validates scalable control graphics', async ({ page }) => {
+  await page.goto('/');
+  await assertSvgGeometry({
+    page,
+    expect,
+    selector: '.hci-icon',
+    label: 'self-test homepage',
+    expectedViewBox: '0 0 24 24',
+  });
+});
+
+test('shared keyboard helper waits for browser-owned smooth focus scrolling at 320px', async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.startsWith('desktop-'), 'keyboard behavior requires a keyboard-capable browser profile');
+  await page.setViewportSize({ width: 320, height: 800 });
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  await assertKeyboardFocusPath({
+    page,
+    expect,
+    selector: 'nav a, #theme-select, a.hci-primary',
+    label: `${testInfo.project.name} 320px smooth-focus fixture`,
+  });
+});


### PR DESCRIPTION
## Summary

Promotes only the static-HCI behavior that proved portable across the Bridge and VanillaCord public-site pilots into the existing public readiness lab.

### Shared helper
Adds `scripts/public-web/static-hci-playwright.mjs` with consumer-configured assertions for:
- document title/H1/heading structure and narrow standalone-action naming checks;
- declared-primary rendered target geometry (44 CSS px default project target);
- actual keyboard `Tab` reachability plus focus-not-obscured geometry;
- objective SVG `viewBox`, rendered-size, and aspect-ratio checks.

Routes, selectors, tooltip semantics, branding, journeys, and application layout remain consumer-owned.

### Validator lesson encoded
The keyboard helper preserves the modality it claims to test. It does not use `focus()`, `scrollIntoView()`, or synthetic scrolling to make controls pass. It permits browser-owned asynchronous/smooth focus scrolling to converge for the same still-focused element before viewport/obstruction measurement.

This incorporates the second-consumer finding from VanillaCord: Chromium/WebKit could transfer focus correctly while an immediate same-turn geometry sample ran before native smooth focus scrolling completed.

### Regression fixture
The existing public-site-readiness Playwright suite now includes a dedicated shared-helper spec. Its synthetic page deliberately enables smooth scrolling and places a declared keyboard target below the initial 320px desktop viewport, so the timing boundary is exercised rather than hidden by an all-above-the-fold fixture.

### Provenance
Bridge first consumer:
- qualified head `47246d3f9f61ca82d5bc5608fffaa2def375cd85`
- production revision `6ab755cda7a4b4cc03f132f1c2b6345c72ea9afd`
- production Pages run `33299901550`

VanillaCord independent second consumer:
- first rebased candidate `0356046a3c0478e0b386524b64aea3d72dbb7efe`
- failing readiness run `33306063467` exposed the timing assumption
- corrected qualified head `8e77e4e8782c406231cc15fc68c4069715760b59`
- production revision `c4b4c5c6aace99b936d9b68576b49c32d9775338`
- post-merge readiness `33307252201`
- production Pages `33307252171`

## Acceptance

Do not merge unless the exact PR head passes the lab's public-site readiness self-test and public-boundary/security validation. After merge, bind the immutable lab revision into the staged engineering/brand governance evidence before promoting those governance candidates.